### PR TITLE
Operator deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,3 +2,6 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.15 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-cloud-controller-manager-operator
 COPY . .
 RUN make build
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/bin/cluster-controller-manager-operator .

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ generate: controller-gen
 
 # Build the docker image
 .PHONY: image
-image: test
+image:
 	docker build -t ${IMG} .
 
 # Push the docker image

--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac.yaml
@@ -37,6 +37,38 @@ rules:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-cloud-controller-manager
+  namespace: openshift-cloud-controller-manager-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - create
+      - update
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:openshift:controller:cloud-controller-manager
@@ -51,3 +83,20 @@ subjects:
 - kind: ServiceAccount
   namespace: openshift-cloud-controller-manager-operator
   name: cluster-cloud-controller-manager
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-cloud-controller-manager
+  namespace: openshift-cloud-controller-manager-operator
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: cluster-cloud-controller-manager
+subjects:
+  - kind: ServiceAccount
+    namespace: openshift-cloud-controller-manager-operator
+    name: cluster-cloud-controller-manager

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-cloud-controller-manager
+  namespace: openshift-cloud-controller-manager-operator
+  labels:
+    k8s-app: cloud-manager-operator
+spec:
+  selector:
+    matchLabels:
+      k8s-app: cloud-manager-operator
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: cloud-manager-operator
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: cluster-cloud-controller-manager
+      containers:
+      - name: cluster-cloud-controller-manager
+        image: registry.svc.ci.openshift.org/openshift:cluster-cloud-controller-manager
+        command:
+        - "/cluster-controller-manager-operator"
+        args:
+        - --leader-elect
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
+        resources:
+          requests:
+            cpu: 10m
+            memory: 50Mi
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      restartPolicy: Always
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      - key: "node.kubernetes.io/unreachable"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoExecute"
+        tolerationSeconds: 120

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -1,0 +1,8 @@
+kind: ImageStream
+apiVersion: image.openshift.io/v1
+spec:
+  tags:
+  - name: cluster-cloud-controller-manager-operator
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:cluster-cloud-controller-manager


### PR DESCRIPTION
Manifest for image referencing and operator deployment, which will be later populated by CI.

To test image in production here is a temporary operator image location `quay.io/dgrigore/cluster-cloud-controller-manager-operator:latest`.