### PR TITLE
Add label in Dockerfile to include operator in CI release images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,5 @@ RUN make build
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/bin/cluster-controller-manager-operator .
 COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/manifests manifests
+
+LABEL io.openshift.release.operator true


### PR DESCRIPTION
`@cluster-bot launch 4.7.0-fc.3,openshift/cluster-cloud-controller-manager-operator#7 aws` should give desired operator in a cluster.