### PR TITLE
Revert "Add label to include in CI release images"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,3 @@ RUN make build
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/bin/cluster-controller-manager-operator .
 COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/manifests manifests
-
-LABEL io.openshift.release.operator true


### PR DESCRIPTION
This reverts commit 184c512942387c073f676e5bbe74dad3de2b3260, #7.

This is breaking release promotion, with failures [like][1]:

    ClusterOperators should define at least one namespace in their lists of related objects

Please don't add yourself to the release image until you have a presubmit running the standard break-the-world e2e suite.

[1]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-4.8/1359162296110157824