### PR TITLE
[OCPCLOUD-1110] Add e2e tests for managed resources provisioning

### DIFF
--- a/controllers/clusteroperator_controller.go
+++ b/controllers/clusteroperator_controller.go
@@ -83,6 +83,7 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 	resources := getResources(infra)
 	if err := r.sync(ctx, resources); err != nil {
 		klog.Errorf("Unable to sync operands: %s", err)
+		return ctrl.Result{}, err
 	}
 
 	if err := r.statusAvailable(ctx); err != nil {


### PR DESCRIPTION
Add a test case for provisioning managed resources. Was tested locally on https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/15, but will later require some changes in the way we configure flags on the deployment. This change although is self sufficient.