### PR TITLE
Revert "Revert "Add label to include in CI release images""

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,3 +6,5 @@ RUN make build
 FROM registry.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/bin/cluster-controller-manager-operator .
 COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/manifests manifests
+
+LABEL io.openshift.release.operator true

--- a/controllers/clusteroperator_controller.go
+++ b/controllers/clusteroperator_controller.go
@@ -128,8 +128,10 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 }
 
 func (r *CloudOperatorReconciler) relatedObjects() []configv1.ObjectReference {
+	// TBD: Add an actual set of object references from getResources method
 	return []configv1.ObjectReference{
 		{Resource: "namespaces", Name: defaultManagementNamespace},
+		{Group: configv1.GroupName, Resource: "clusteroperators", Name: defaultManagementNamespace},
 		{Resource: "namespaces", Name: r.ManagedNamespace},
 	}
 }


### PR DESCRIPTION
Reverts openshift/cluster-cloud-controller-manager-operator#14 in attempt to add operator back to release.

We should have basic e2e for AWS running now. @wking PTAL