### PR TITLE
Add images config map

### DIFF
--- a/cmd/cluster-cloud-controller-manager-operator/main.go
+++ b/cmd/cluster-cloud-controller-manager-operator/main.go
@@ -48,7 +48,10 @@ var (
 	retryPeriod   = 90 * time.Second
 )
 
-const defaultManagedNamespace = "openshift-cloud-controller-manager"
+const (
+	defaultManagedNamespace = "openshift-cloud-controller-manager"
+	defaultImagesLocation   = "/etc/cloud-controller-manager-config/images.json"
+)
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -97,6 +100,12 @@ func main() {
 		"The namespace for managed objects, where out-of-tree CCM binaries will run.",
 	)
 
+	imagesFile := flag.String(
+		"images-json",
+		defaultImagesLocation,
+		"The location of images file to use by operator for managed CCM binaries.",
+	)
+
 	flag.Parse()
 
 	ctrl.SetLogger(klogr.New().WithName("CCMOperator"))
@@ -125,6 +134,7 @@ func main() {
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
 		ManagedNamespace: *managedNamespace,
+		ImagesFile:       *imagesFile,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterOperator")
 		os.Exit(1)

--- a/controllers/clusteroperator_controller.go
+++ b/controllers/clusteroperator_controller.go
@@ -59,6 +59,7 @@ type CloudOperatorReconciler struct {
 	Scheme           *runtime.Scheme
 	watcher          ObjectWatcher
 	ManagedNamespace string
+	ImagesFile       string
 }
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list;watch;create;update;patch;delete

--- a/hack/example-images.json
+++ b/hack/example-images.json
@@ -1,0 +1,4 @@
+{
+    "cloudControllerManagerAWS": "registry.svc.ci.openshift.org/openshift:aws-cloud-controller-manager",
+    "cloudControllerManagerOpenStack": "registry.svc.ci.openshift.org/openshift:openstack-cloud-controller-manager"
+}

--- a/manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-controller-manager-images
+  namespace: openshift-cloud-controller-manager-operator
+data:
+  images.json: >
+    {
+      "cloudControllerManagerAWS": "registry.svc.ci.openshift.org/openshift:aws-cloud-controller-manager",
+      "cloudControllerManagerOpenStack": "registry.svc.ci.openshift.org/openshift:openstack-cloud-controller-manager"
+    }

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -27,6 +27,7 @@ spec:
         - "/cluster-controller-manager-operator"
         args:
         - --leader-elect
+        - "--images-json=/etc/cloud-controller-manager-config/images.json"
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
@@ -34,6 +35,9 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        volumeMounts:
+        - name: images
+          mountPath: /etc/cloud-controller-manager-config/
       nodeSelector:
         node-role.kubernetes.io/master: ""
       restartPolicy: Always
@@ -49,3 +53,8 @@ spec:
         operator: "Exists"
         effect: "NoExecute"
         tolerationSeconds: 120
+      volumes:
+      - name: images
+        configMap:
+          defaultMode: 420
+          name: machine-api-operator-images

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,3 +6,11 @@ spec:
     from:
       kind: DockerImage
       name: registry.svc.ci.openshift.org/openshift:cluster-cloud-controller-manager-operator
+  - name: aws-machine-controllers
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:aws-cloud-controller-manager
+  - name: openstack-machine-controllers
+    from:
+      kind: DockerImage
+      name: registry.svc.ci.openshift.org/openshift:openstack-cloud-controller-manager


### PR DESCRIPTION
Mount config map into `CCCMO` deployment for correct image version
evaluation on operator startup. Images will be dynamically passed to
operand controllers.

To deploy operator locally you now need to specify a command line argument:
```bash
./bin/cluster-controller-manager-operator --images-json=hack/example-images.json
```