### PR TITLE
Provider image substitution

### DIFF
--- a/controllers/config.go
+++ b/controllers/config.go
@@ -1,0 +1,57 @@
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	configv1 "github.com/openshift/api/config/v1"
+)
+
+// imagesReference allows build systems to inject imagesReference for CCCMO components
+type imagesReference struct {
+	CloudControllerManagerAWS       string `json:"cloudControllerManagerAWS"`
+	CloudControllerManagerOpenStack string `json:"cloudControllerManagerOpenStack"`
+}
+
+// operatorConfig contains configuration values for templating resources
+type operatorConfig struct {
+	ManagedNamespace string
+	ControllerImage  string
+}
+
+func getProviderFromInfrastructure(infra *configv1.Infrastructure) (configv1.PlatformType, error) {
+	if infra == nil || infra.Status.PlatformStatus == nil {
+		return "", fmt.Errorf("platform status is not pupulated on infrastructure")
+	}
+	if infra.Status.PlatformStatus.Type == "" {
+		return "", fmt.Errorf("no platform provider found on infrastructure")
+	}
+
+	return infra.Status.PlatformStatus.Type, nil
+}
+
+func getImagesFromJSONFile(filePath string) (imagesReference, error) {
+	data, err := ioutil.ReadFile(filepath.Clean(filePath))
+	if err != nil {
+		return imagesReference{}, err
+	}
+
+	i := imagesReference{}
+	if err := json.Unmarshal(data, &i); err != nil {
+		return imagesReference{}, err
+	}
+	return i, nil
+}
+
+func getProviderControllerFromImages(platform configv1.PlatformType, images imagesReference) string {
+	switch platform {
+	case configv1.AWSPlatformType:
+		return images.CloudControllerManagerAWS
+	case configv1.OpenStackPlatformType:
+		return images.CloudControllerManagerOpenStack
+	default:
+		return ""
+	}
+}

--- a/controllers/config_test.go
+++ b/controllers/config_test.go
@@ -1,0 +1,183 @@
+package controllers
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+func TestGetImagesFromJSONFile(t *testing.T) {
+	tc := []struct {
+		name           string
+		path           string
+		imagesContent  string
+		expectedImages imagesReference
+		expectError    bool
+	}{{
+		name: "Unmarshal images from file",
+		path: "images_file",
+		imagesContent: `{
+    "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+    "cloudControllerManagerOpenStack": "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager"
+}`,
+		expectedImages: imagesReference{
+			CloudControllerManagerAWS:       "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+			CloudControllerManagerOpenStack: "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager",
+		},
+	}, {
+		name:        "Error on non present file",
+		expectError: true,
+	}, {
+		name: "Partial content is accepted",
+		path: "images_file",
+		imagesContent: `{
+    "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:aws-cloud-controller-manager"
+}`,
+		expectedImages: imagesReference{
+			CloudControllerManagerAWS: "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+		},
+	}, {
+		name: "Duplicate content takes precedence and is accepted",
+		path: "images_file",
+		imagesContent: `{
+    "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+    "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:different"
+}`,
+		expectedImages: imagesReference{
+			CloudControllerManagerAWS: "registry.ci.openshift.org/openshift:different",
+		},
+	}, {
+		name: "Unknown image name is ignored",
+		path: "images_file",
+		imagesContent: `{
+    "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+    "cloudControllerManagerUnknown": "registry.ci.openshift.org/openshift:unknown-cloud-controller-manager",
+    "cloudControllerManagerOpenStack": "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager"
+}`,
+		expectedImages: imagesReference{
+			CloudControllerManagerAWS:       "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+			CloudControllerManagerOpenStack: "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager",
+		},
+	},
+		{
+			name: "Broken JSON is rejected",
+			path: "images_file",
+			imagesContent: `{
+    "cloudControllerManagerAWS": BAD,
+}`,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			path := "./not_found"
+			if tc.path != "" {
+				file, err := ioutil.TempFile(os.TempDir(), tc.path)
+				path = file.Name()
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer file.Close()
+
+				_, err = file.WriteString(tc.imagesContent)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			images, err := getImagesFromJSONFile(path)
+			if isErr := err != nil; isErr != tc.expectError {
+				t.Fatalf("Unexpected error result: %v", err)
+			}
+
+			if !equality.Semantic.DeepEqual(images, tc.expectedImages) {
+				t.Errorf("Images are not set correctly:\n%v\nexpected\n%v", images, tc.expectedImages)
+			}
+		})
+	}
+}
+
+func TestGetProviderFromInfrastructure(t *testing.T) {
+	tc := []struct {
+		name           string
+		infra          *configv1.Infrastructure
+		expectPlatform configv1.PlatformType
+		expectErr      bool
+	}{{
+		name:      "Passing empty infra causes error",
+		infra:     nil,
+		expectErr: true,
+	}, {
+		name: "No platform type causes error",
+		infra: &configv1.Infrastructure{
+			Status: configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{},
+			},
+		},
+		expectErr: true,
+	}, {
+		name: "All good",
+		infra: &configv1.Infrastructure{
+			Status: configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: "some_platform",
+				},
+			},
+		},
+		expectPlatform: "some_platform",
+	}}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			platform, err := getProviderFromInfrastructure(tc.infra)
+			if isErr := (err != nil); tc.expectErr != isErr {
+				t.Fatalf("Unexpected error result: %v", err)
+			}
+			if platform != tc.expectPlatform {
+				t.Errorf("Unexpected platform %s, expected %s", platform, tc.expectPlatform)
+			}
+		})
+	}
+}
+
+func TestGetProviderControllerFromImages(t *testing.T) {
+	images := imagesReference{
+		CloudControllerManagerAWS:       "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+		CloudControllerManagerOpenStack: "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager",
+	}
+
+	tc := []struct {
+		name          string
+		platformType  configv1.PlatformType
+		expectedImage string
+	}{{
+		name:          "AWS platorm",
+		platformType:  configv1.AWSPlatformType,
+		expectedImage: "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+	}, {
+		name:          "Azure platorm",
+		platformType:  configv1.AzurePlatformType,
+		expectedImage: "",
+	}, {
+		name:          "OpenStack platorm",
+		platformType:  configv1.OpenStackPlatformType,
+		expectedImage: "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager",
+	}, {
+		name:          "Unknown platorm",
+		platformType:  "unknown",
+		expectedImage: "",
+	}}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			image := getProviderControllerFromImages(tc.platformType, images)
+			if image != tc.expectedImage {
+				t.Errorf("Unexpected image %s, expected %s", image, tc.expectedImage)
+			}
+		})
+	}
+}

--- a/controllers/substitution.go
+++ b/controllers/substitution.go
@@ -1,0 +1,42 @@
+package controllers
+
+import (
+	v1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// Names in this list are unique and will be substituted with an image from config
+	// cloudControllerManagerName is a name for default CCM controller container any provider may have
+	cloudControllerManagerName = "cloud-controller-manager"
+)
+
+// setDeploymentImages substitutes controller containers in Deployment with correct image
+func setDeploymentImages(config operatorConfig, d *v1.Deployment) {
+	for i, container := range d.Spec.Template.Spec.Containers {
+		if container.Name != cloudControllerManagerName {
+			continue
+		}
+
+		d.Spec.Template.Spec.Containers[i].Image = config.ControllerImage
+	}
+}
+
+func fillConfigValues(config operatorConfig, templates []client.Object) []client.Object {
+	objects := make([]client.Object, len(templates))
+	for i, objectTemplate := range templates {
+		templateCopy := objectTemplate.DeepCopyObject().(client.Object)
+
+		// Set namespaces for all object. Namespace on cluster-wide objects is stripped by API server and is not applied
+		templateCopy.SetNamespace(config.ManagedNamespace)
+
+		dep, ok := templateCopy.(*v1.Deployment)
+		if ok {
+			setDeploymentImages(config, dep)
+			// TODO: add cloud-config calculated hash to annotations to account for redeployment on content change
+		}
+
+		objects[i] = templateCopy
+	}
+	return objects
+}

--- a/controllers/substitution_test.go
+++ b/controllers/substitution_test.go
@@ -1,0 +1,192 @@
+package controllers
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestSetDeploymentImages(t *testing.T) {
+	tc := []struct {
+		name               string
+		containers         []corev1.Container
+		config             operatorConfig
+		expectedContainers []corev1.Container
+	}{{
+		name: "Unknown container name",
+		containers: []corev1.Container{{
+			Name:  "different_name",
+			Image: "no_change",
+		}},
+		expectedContainers: []corev1.Container{{
+			Name:  "different_name",
+			Image: "no_change",
+		}},
+		config: operatorConfig{
+			ControllerImage: "correct_image:tag",
+		},
+	}, {
+		name: "Substitute cloud-controller-manager container image",
+		containers: []corev1.Container{{
+			Name:  cloudControllerManagerName,
+			Image: "expect_change",
+		}},
+		expectedContainers: []corev1.Container{{
+			Name:  cloudControllerManagerName,
+			Image: "correct_image:tag",
+		}},
+		config: operatorConfig{
+			ControllerImage: "correct_image:tag",
+		},
+	}, {
+		name: "Combination of container image names",
+		containers: []corev1.Container{{
+			Name:  cloudControllerManagerName,
+			Image: "expect_change",
+		}, {
+			Name:  "node-controller-manager",
+			Image: "no_change",
+		}},
+		expectedContainers: []corev1.Container{{
+			Name:  cloudControllerManagerName,
+			Image: "correct_image:tag",
+		}, {
+			Name:  "node-controller-manager",
+			Image: "no_change",
+		}},
+		config: operatorConfig{
+			ControllerImage: "correct_image:tag",
+		},
+	}}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			deploy := &v1.Deployment{
+				Spec: v1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: tc.containers,
+						},
+					},
+				},
+			}
+
+			setDeploymentImages(tc.config, deploy)
+
+			if !equality.Semantic.DeepEqual(deploy.Spec.Template.Spec.Containers, tc.expectedContainers) {
+				t.Errorf("Container images are not set correctly:\n%v\nexpected\n%v", deploy.Spec.Template.Spec.Containers, tc.expectedContainers)
+			}
+		})
+	}
+
+}
+
+func TestFillConfigValues(t *testing.T) {
+	tc := []struct {
+		name            string
+		objects         []client.Object
+		config          operatorConfig
+		expectedObjects []client.Object
+	}{{
+		name:    "Substitute object namespace",
+		objects: []client.Object{&corev1.ConfigMap{}},
+		expectedObjects: []client.Object{&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testManagementNamespace,
+			},
+		}},
+		config: operatorConfig{
+			ManagedNamespace: testManagementNamespace,
+		},
+	}, {
+		name: "Substitute cloud-controller-manager container image and namespace",
+		objects: []client.Object{&v1.Deployment{
+			Spec: v1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  cloudControllerManagerName,
+							Image: "expect_change",
+						}},
+					},
+				},
+			},
+		}},
+		expectedObjects: []client.Object{&v1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: testManagementNamespace,
+			},
+			Spec: v1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  cloudControllerManagerName,
+							Image: "correct_image:tag",
+						}},
+					},
+				},
+			},
+		}},
+		config: operatorConfig{
+			ControllerImage:  "correct_image:tag",
+			ManagedNamespace: testManagementNamespace,
+		},
+	}, {
+		name: "Substitute image and namespace for more objects at once",
+		objects: []client.Object{&corev1.ConfigMap{}, &v1.Deployment{
+			Spec: v1.DeploymentSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  cloudControllerManagerName,
+							Image: "expect_change",
+						}},
+					},
+				},
+			},
+		}},
+		expectedObjects: []client.Object{
+			&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testManagementNamespace,
+				},
+			}, &v1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testManagementNamespace,
+				},
+				Spec: v1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{
+								Name:  cloudControllerManagerName,
+								Image: "correct_image:tag",
+							}},
+						},
+					},
+				},
+			}},
+		config: operatorConfig{
+			ControllerImage:  "correct_image:tag",
+			ManagedNamespace: testManagementNamespace,
+		},
+	}}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+
+			initialObjects := tc.objects
+			updatedObjects := fillConfigValues(tc.config, tc.objects)
+
+			if !equality.Semantic.DeepEqual(updatedObjects, tc.expectedObjects) {
+				t.Errorf("Objects are not equal expected: \n%v, \n\nexpected %v", updatedObjects, tc.expectedObjects)
+			}
+			if !equality.Semantic.DeepEqual(initialObjects, tc.objects) {
+				t.Errorf("Objects were mutated in place unexpectingly")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR allows operator to dynamically configure image in provisioned resources such as CCM Deployment. 

This is done based on assumption that every CCM controller will be in a named container containing `controller` substring in it's name. All those containers images will be managed by operator, others will remain unchanged from initial manifest.

Operator is now populating Namespace for each resource it provisions. Cluster-scoped resources are also getting this namespace value, which is ok as it is not accounted and is not stored by API server on apply. This allows two operators to manage equivalent set of resources in different namespaces without clashes.

- [x] Testing