### PR TITLE
Add management workload annotations

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_00_namespace.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_00_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
@@ -17,6 +18,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -15,6 +15,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: cloud-manager-operator
     spec:

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -12,6 +12,8 @@ spec:
       k8s-app: aws-cloud-controller-manager
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: aws-cloud-controller-manager
     spec:

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -11,6 +11,8 @@ spec:
       app: openstack-cloud-controller-manager
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openstack-cloud-controller-manager
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>