### PR TITLE
Add anti-affinity settings to preserve HA for CCM pods

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -48,3 +48,5 @@ spec:
         key: node.kubernetes.io/not-ready
         operator: Exists
         tolerationSeconds: 120
+      - effect: NoSchedule
+        key: node.cloudprovider.kubernetes.io/uninitialized

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: aws-cloud-controller-manager
   namespace: openshift-cloud-controller-manager
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       k8s-app: aws-cloud-controller-manager
@@ -26,6 +26,15 @@ spec:
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  k8s-app: aws-cloud-controller-manager
       serviceAccountName: cloud-controller-manager
       tolerations:
       - effect: NoSchedule

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: openstack-cloud-controller-manager
 spec:
+  replicas: 2
   selector:
     matchLabels:
       app: openstack-cloud-controller-manager
@@ -19,6 +20,15 @@ spec:
       priorityClassName: system-cluster-critical
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: openstack-cloud-controller-manager
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists


### PR DESCRIPTION
Following proposal we need to run at least 2 replicas of CCM
controllers scheduled on different master nodes for HA: 
https://github.com/openshift/enhancements/pull/463/files#diff-3e0e2c48e70215076dfe36c13768a823ab7080d929d80292f37db2ef5a2121e8R123

Requires pieces from https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/15 to be merged first.