### PR TITLE
Add missing requests to AWS and OpenStack CCM deployments

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -25,6 +25,10 @@ spec:
         image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.19.0-alpha.1
         imagePullPolicy: IfNotPresent
         name: aws-cloud-controller-manager
+        resources:
+          requests:
+            cpu: 200m
+            memory: 50Mi
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -55,6 +55,10 @@ spec:
             - --use-service-account-credentials=true
             - --bind-address=127.0.0.1
             - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+          resources:
+            requests:
+              cpu: 200m
+              memory: 50Mi
           volumeMounts:
             - name: secret-occm
               mountPath: /etc/kubernetes/secret


### PR DESCRIPTION
OpenStack pod requests are inheriting upstream values: https://github.com/kubernetes/cloud-provider-openstack/blob/master/manifests/controller-manager/openstack-cloud-controller-manager-ds.yaml#L57-L59

AWS manifests: https://github.com/kubernetes/cloud-provider-aws/blob/master/manifests/aws-cloud-controller-manager-daemonset.yaml#L35-L37

More precise values could only be determined after https://github.com/openshift/library-go/pull/895 and https://github.com/openshift/machine-config-operator/pull/2386 are merged.