### PR TITLE
Bug 1957879: Pre-create relatedObjects in the cluster operator

### DIFF
--- a/controllers/clusteroperator_controller.go
+++ b/controllers/clusteroperator_controller.go
@@ -148,7 +148,7 @@ func (r *CloudOperatorReconciler) relatedObjects() []configv1.ObjectReference {
 	// TBD: Add an actual set of object references from getResources method
 	return []configv1.ObjectReference{
 		{Resource: "namespaces", Name: defaultManagementNamespace},
-		{Group: configv1.GroupName, Resource: "clusteroperators", Name: defaultManagementNamespace},
+		{Group: configv1.GroupName, Resource: "clusteroperators", Name: clusterOperatorName},
 		{Resource: "namespaces", Name: r.ManagedNamespace},
 	}
 }

--- a/manifests/0000_26_cloud-controller-manager-operator_12_clusteroperator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_12_clusteroperator.yaml
@@ -11,3 +11,13 @@ status:
   versions:
     - name: operator
       version: "0.0.1-snapshot"
+  relatedObjects:
+    - group: config.openshift.io
+      name: cloud-controller-manager
+      resource: clusteroperators
+    - group: ""
+      name: openshift-cloud-controller-manager
+      resource: namespaces
+    - group: ""
+      name: openshift-cloud-controller-manager-operator
+      resource: namespaces


### PR DESCRIPTION
This will allow to collect the logs for must gather if operator does not come up and unblock upgrades until CVO fix will be issued. Operator later populates missing resources.