### PR TITLE
Ensure priorityClass is set on AWS CCM

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         k8s-app: aws-cloud-controller-manager
     spec:
+      priorityClassName: system-cluster-critical
       containers:
       - args:
         - --cloud-provider=aws
@@ -35,7 +36,7 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
+          - weight: 100
             podAffinityTerm:
               topologyKey: "kubernetes.io/hostname"
               labelSelector:


### PR DESCRIPTION
Satisfy requirements of "[sig-arch] Managed cluster should ensure platform components have system-* priority class associated"

Full log: https://console.build01.ci.openshift.org/api/kubernetes/api/v1/namespaces/ci-op-6t1wq5k4/pods/e2e-aws-ccm-openshift-e2e-test/log?container=test

Increase weight on affinity settings to ensure the two pods are not scheduled on the same Node in edge cases.

Reasoning: 
https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/#marking-pod-as-critical

OpenStack manifests have that same field. Cluster will not become healthy during install if those pods are not healthy. Not `system-node-critical` as provisioned Nodes could operate without these pods running.
