### PR TITLE
Ensure AWS and OpenStack CCM container names are fit for image substitution

### DIFF
--- a/controllers/substitution.go
+++ b/controllers/substitution.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	v1 "k8s.io/api/apps/v1"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -18,6 +19,7 @@ func setDeploymentImages(config operatorConfig, d *v1.Deployment) {
 			continue
 		}
 
+		klog.Infof("Substituting %q: %s", container.Name, config.ControllerImage)
 		d.Spec.Template.Spec.Containers[i].Image = config.ControllerImage
 	}
 }

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         - -v=2
         image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.19.0-alpha.1
         imagePullPolicy: IfNotPresent
-        name: aws-cloud-controller-manager
+        name: cloud-controller-manager
         resources:
           requests:
             cpu: 200m

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -41,7 +41,7 @@ spec:
           value: "true"
           effect: NoSchedule
       containers:
-        - name: openstack-cloud-controller-manager
+        - name: cloud-controller-manager
           image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:latest
           imagePullPolicy: "IfNotPresent"
           env:


### PR DESCRIPTION
`cloud-controller-manager` is currently the only name in our image substitution pattern accepts as valid. All platform manifests should follow this naming if the image is expected to be substituted.