### PR TITLE
update all target in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-all: operator
+all: build
 
 # Run tests
 ENVTEST_ASSETS_DIR=/tmp/testbin


### PR DESCRIPTION
this removes the unused `operator` target in favor of `build` for all
targets.