### PR TITLE
Add generation of azure static CCM pod to bootstrap

### DIFF
--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -1,0 +1,36 @@
+package azure
+
+import (
+	"embed"
+
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/common"
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	//go:embed bootstrap/*
+	azureBootstrapFS embed.FS
+
+	azureBootstrapResoureces []client.Object
+	azureBootstrapSources    = []common.ObjectSource{
+		{Object: &corev1.Pod{}, Path: "bootstrap/pod.yaml"},
+	}
+)
+
+func init() {
+	var err error
+	azureBootstrapResoureces, err = common.ReadResources(azureBootstrapFS, azureBootstrapSources)
+	utilruntime.Must(err)
+}
+
+// GetBootstrapResources returns a list static pods for provisioning CCM on bootstrap node for Azure
+func GetBootstrapResources() []client.Object {
+	resources := make([]client.Object, len(azureBootstrapResoureces))
+	for i := range azureBootstrapResoureces {
+		resources[i] = azureBootstrapResoureces[i].DeepCopyObject().(client.Object)
+	}
+
+	return resources
+}

--- a/pkg/cloud/azure/azure_test.go
+++ b/pkg/cloud/azure/azure_test.go
@@ -1,0 +1,21 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBootstrapResources(t *testing.T) {
+	resources := GetBootstrapResources()
+	assert.Len(t, resources, 1)
+
+	var names, kinds []string
+	for _, r := range resources {
+		names = append(names, r.GetName())
+		kinds = append(kinds, r.GetObjectKind().GroupVersionKind().Kind)
+	}
+
+	assert.Contains(t, names, "azure-cloud-controller-manager")
+	assert.Contains(t, kinds, "Pod")
+}

--- a/pkg/cloud/azure/bootstrap/pod.yaml
+++ b/pkg/cloud/azure/bootstrap/pod.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: azure-cloud-controller-manager
+  namespace: kube-system
+spec:
+  priorityClassName: system-node-critical
+  hostNetwork: true
+  containers:
+    - name: cloud-controller-manager
+      image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.0
+      imagePullPolicy: IfNotPresent
+      command: ["cloud-controller-manager"]
+      args:
+        - --cloud-provider=azure
+        - --controllers=cloud-node # run cloud-node controller only for Node initialization
+        - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
+        - --cloud-config=/etc/kubernetes/configs/cloud.conf
+        - --leader-elect=false
+        - --port=10267
+        - -v=2
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 10267
+        initialDelaySeconds: 20
+        periodSeconds: 10
+        timeoutSeconds: 5
+      volumeMounts:
+      - name: secrets
+        mountPath: /etc/kubernetes/secrets
+      - name: configs
+        mountPath: /etc/kubernetes/configs
+  volumes:
+  - name: secrets
+    hostPath:
+      path: /etc/kubernetes/bootstrap-secrets
+  - name: configs
+    hostPath:
+      path: /etc/kubernetes/bootstrap-configs

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -3,6 +3,7 @@ package cloud
 import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/aws"
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/azure"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/openstack"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,6 +38,8 @@ func GetBootstrapResources(platform configv1.PlatformType) []client.Object {
 	switch platform {
 	case configv1.AWSPlatformType:
 		return aws.GetBootstrapResources()
+	case configv1.AzurePlatformType:
+		return azure.GetBootstrapResources()
 	default:
 		klog.Warning("No recognized cloud provider platform found in infrastructure")
 		return nil

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -5,6 +5,7 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/aws"
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/azure"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/openstack"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -88,8 +89,9 @@ func TestGetBootstrapResources(t *testing.T) {
 		name:     "GCP resources are empty, as the platform is not yet supported",
 		platform: configv1.GCPPlatformType,
 	}, {
-		name:     "Azure resources are empty, as the platform is not yet supported",
+		name:     "Azure resources returned as expected",
 		platform: configv1.AzurePlatformType,
+		expected: azure.GetBootstrapResources(),
 	}, {
 		name:     "VSphere resources are empty, as the platform is not yet supported",
 		platform: configv1.VSpherePlatformType,


### PR DESCRIPTION
The PR would allow to create Azure static pod to bootstrap node. The pod would look like so:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: azure-cloud-controller-manager
  namespace: kube-system
spec:
  priorityClassName: system-node-critical
  hostNetwork: true
  containers:
    - name: cloud-controller-manager
      image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.0
      imagePullPolicy: IfNotPresent
      command: ["cloud-controller-manager"]
      args:
        - --cloud-provider=azure
        - --controllers=cloud-node # run cloud-node controller only for Node initialization
        - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
        - --cloud-config=/etc/kubernetes/configs/cloud.conf # cloud config is generated by https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/55
        # and copied to /etc/kubernetes/bootstrap-configs by bootkube.sh https://github.com/openshift/installer/pull/4947
        - --leader-elect=false
        - --port=10267
        - -v=2
      livenessProbe:
        httpGet:
          path: /healthz
          port: 10267
        initialDelaySeconds: 20
        periodSeconds: 10
        timeoutSeconds: 5
      volumeMounts:
      - name: secrets
        mountPath: /etc/kubernetes/secrets
      - name: configs
        mountPath: /etc/kubernetes/configs
  volumes:
  - name: secrets
    hostPath:
      path: /etc/kubernetes/bootstrap-secrets
  - name: configs
    hostPath:
      path: /etc/kubernetes/bootstrap-configs
```

Azure CCM require cloud config flag. The file would be unpacked and delivered to the pod by the implementation in https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/55