### PR TITLE
Tolerate uninitialized taint in operator pods

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -44,6 +44,9 @@ spec:
         node-role.kubernetes.io/master: ""
       restartPolicy: Always
       tolerations:
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        effect: NoSchedule
+        value: "true"
       - key: "node-role.kubernetes.io/master"
         operator: "Exists"
         effect: "NoSchedule"

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -57,3 +57,4 @@ spec:
         tolerationSeconds: 120
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"


### PR DESCRIPTION
Operator has to be able to start on master Nodes, when all of them are
marked as uninitialized. Additionally not-ready taint has NoSchedule
effect on Nodes when the deadlock happens.