### PR TITLE
Use strict yaml unmarshal to ensure partial type safety

### DIFF
--- a/pkg/cloud/common/_testdata/assets/deployment.yaml
+++ b/pkg/cloud/common/_testdata/assets/deployment.yaml
@@ -4,6 +4,7 @@ metadata:
   name: sample
   namespace: sample
 spec:
+  replicas: 1
   selector:
     matchLabels:
       k8s-app: aws-cloud-controller-manager

--- a/pkg/cloud/common/sources.go
+++ b/pkg/cloud/common/sources.go
@@ -1,12 +1,11 @@
 package common
 
 import (
-	"bytes"
 	"embed"
 
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
 )
 
 type ObjectSource struct {
@@ -24,8 +23,7 @@ func ReadResources(f embed.FS, sources []ObjectSource) ([]client.Object, error) 
 		}
 
 		object := source.Object.DeepCopyObject().(client.Object)
-		dec := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(data), 1000)
-		if err := dec.Decode(object); err != nil {
+		if err := yaml.UnmarshalStrict(data, object); err != nil {
 			klog.Errorf("Cannot decode data from embedded resource %v: %v", source.Path, err)
 			return nil, err
 		}

--- a/pkg/cloud/common/sources_test.go
+++ b/pkg/cloud/common/sources_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 //go:embed _testdata/*
@@ -51,6 +52,20 @@ func TestReadResources(t *testing.T) {
 			{Object: &appsv1.Deployment{}, Path: "_testdata/foo"},
 		},
 		expectedError: "error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type v1.Deployment",
+	}, {
+		name: "Incorrect resource type should not be unmarshalled",
+		fs:   assetPath,
+		sources: []ObjectSource{
+			{Object: &appsv1.DaemonSet{}, Path: "_testdata/assets/deployment.yaml"},
+		},
+		expectedError: "error unmarshaling JSON: while decoding JSON: json: unknown field \"replicas\"",
+	}, {
+		name: "Incorrect resource type should not be unmarshalled",
+		fs:   assetPath,
+		sources: []ObjectSource{
+			{Object: &v1.PersistentVolume{}, Path: "_testdata/assets/deployment.yaml"},
+		},
+		expectedError: "error unmarshaling JSON: while decoding JSON: json: unknown field \"replicas\"",
 	}}
 
 	for _, tc := range tc {


### PR DESCRIPTION
Is seems a deployment without replicas is perfectly marshable to
daemonSet, this is a nature of parsing some byte stream to a compatible
resource holder.

cc @lobziik 