### PR TITLE
Add scripts to build a release image with CCM components

### DIFF
--- a/hack/builders/README.md
+++ b/hack/builders/README.md
@@ -1,0 +1,70 @@
+# CCM hacking tools
+
+## Prerequisites
+
+It's critical to correctly configure the credentials here or the building process will fail with permission errors.
+
+### Accessing registry.ci.openshift.org
+
+For registry.ci.openshift.org, you first need to copy the token from https://oauth-openshift.apps.ci.l2s4.p1.openshiftapps.com/oauth/token/request (top left, "Display Token") and run this command:
+
+```sh
+podman login -u <username> -p <token> https://registry.ci.openshift.org
+```
+
+### Obtaining OpenShift's quay.io credentials
+
+For OpenShift's quay.io, the credentials need to be taken from https://cloud.redhat.com/openshift/create/local. Click `Download pull secret` and store `pull-secret.txt` in a safe location on your computer.
+
+**NOTE:** These are not your personal credentials, you won't be able to use them to access your personal quay.io account. These credentials are required to obtain the base release image only.
+
+## Build an operator image with your custom changes
+
+```txt
+Usage: ./build_operator_image.sh [options]
+Options:
+-h, --help        show this message
+-o, --operator    operator name to build, examples: machine-config-operator, cluster-kube-controller-manager-operator
+-i, --id          id of your pull request to apply on top of the master branch
+-u, --username    registered username in quay.io
+-t, --tag         push to a custom tag in your origin release image repo, default: latest
+-d, --dockerfile  non-default Dockerfile name, default: Dockerfile
+```
+
+For instance, if you want to build a Machine Config Operator image with your custom change specified by PR [\#2606](https://github.com/openshift/machine-config-operator/pull/2606) and then push it into your personal quay.io, execute
+
+```sh
+$ ./build_operator_image.sh --username johndow --operator machine-config-operator --id 2606
+```
+
+**Note**: since Quay doesn't publish images by default, to successfully use the image, you need to make it public manually in the registry web console.
+
+## Build a release image with your custom changes
+
+```txt
+Usage: ./build_release_image.sh [options] -u <quay.io username>
+Options:
+-h, --help      show this message
+-u, --username  registered username in quay.io
+-t, --tag       push to a custom tag in your origin release image repo, default: latest
+-r, --release   openshift release version, default: 4.9
+-a, --auth      path of registry auth file, default: ./pull-secret.txt
+--cccmo         custom cluster-cloud-controller-manager-operator image name, default: quay.io/openshift/origin-cluster-cloud-controller-manager-operator:4.9
+--aws-ccm       custom aws cloud-controller-manager image name, default: quay.io/openshift/origin-aws-cloud-controller-manager:4.9
+--azure-ccm     custom azure cloud-controller-manager image name, default: quay.io/openshift/origin-azure-cloud-controller-manager:4.9
+--azure-node    custom azure node manager image name, default: quay.io/openshift/origin-azure-cloud-node-manager:4.9
+--openstack-ccm custom openstack cloud-controller-manager image name, default: quay.io/openshift/origin-openstack-cloud-controller-manager:4.9
+--kapio         custom kube-apiserver-operator image name, default: current kube-apiserver-operator image from the release payload
+--kcmo          custom kube-controller-manager-operator image name, default: current kube-controller-manager-operator image from the release payload
+--mco           custom machine-config-operator image name, default: current machine-config-operator image from the release payload
+```
+
+To build an actual release image with your custom Machine Config Operator image, that was created in the previous step, execute
+
+```sh
+$ ./build_release_image.sh --username johndow --auth ~/pull-secret.txt --mco quay.io/johndow/machine-config-operator:latest
+```
+
+To replace other component images use the related command line options (`--kcmo` for Kube Controller Manager Operator, `--aws-ccm` for AWS Cloud Controller manager, and so on). It is possible to replace several images at once.
+
+When the building process is over, the script will upload the release image in your personal quay account, so it can be consumed by the installer.

--- a/hack/builders/build_operator_image.sh
+++ b/hack/builders/build_operator_image.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -e
+
+help() {
+    echo "Build an operator image with custom changes to support external cloud providers"
+    echo ""
+    echo "Usage: ./build_operator_image.sh [options]"
+    echo "Options:"
+    echo "-h, --help        show this message"
+    echo "-o, --operator    operator name to build, examples: machine-config-operator, cluster-kube-controller-manager-operator"
+    echo "-i, --id          id of your pull request to apply on top of the master branch"
+    echo "-u, --username    registered username in quay.io"
+    echo "-t, --tag         push to a custom tag in your origin release image repo, default: latest"
+    echo "-d, --dockerfile  non-default Dockerfile name, default: Dockerfile"
+    echo ""
+}
+
+TAG="latest"
+DOCKERFILE="Dockerfile"
+
+# Parse Options
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            help
+            exit 0
+            ;;
+
+        -u|--username)
+            USERNAME=$2
+            shift 2
+            ;;
+
+        -t|--tag)
+            TAG=$2
+            shift 2
+            ;;
+
+        -o|--operator)
+            OPERATOR_NAME=$2
+            shift 2
+            ;;
+
+        -i|--id)
+            PRID=$2
+            shift 2
+            ;;
+
+        -d|--dockerfile)
+            DOCKERFILE=$2
+            shift 2
+            ;;
+
+        *)
+            echo "Invalid option $1"
+            help
+            exit 0
+            ;;
+    esac
+done
+
+if [ -z "$USERNAME" ]; then
+    echo "No quay.io username provided, exiting ..."
+    exit 1
+fi
+
+if [ -z "$OPERATOR_NAME" ]; then
+    echo "No operator name provided, exiting ..."
+    exit 1
+fi
+
+OPERATOR_IMAGE=quay.io/$USERNAME/$OPERATOR_NAME:$TAG
+GITHUB_REPO="https://github.com/openshift/$OPERATOR_NAME"
+
+git ls-remote $GITHUB_REPO 1>/dev/null
+
+echo "Cloning repo $GITHUB_REPO"
+rm -rf $OPERATOR_NAME
+git clone $GITHUB_REPO
+
+pushd $OPERATOR_NAME
+
+echo "Applying your changes"
+git fetch origin pull/$PRID/head:changes
+git checkout changes
+git rebase master
+
+echo "Setting operator image to $OPERATOR_IMAGE"
+
+echo "Start building operator image"
+podman build --no-cache -t $OPERATOR_IMAGE -f $DOCKERFILE
+
+echo "Pushing operator image to quay.io"
+podman push $OPERATOR_IMAGE
+
+popd
+
+echo "Successfully pushed $OPERATOR_IMAGE"
+
+echo "Cleaning up"
+rm -rf $OPERATOR_NAME

--- a/hack/builders/build_release_image.sh
+++ b/hack/builders/build_release_image.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+set -e
+
+help() {
+    echo "Build a release image with custom CCM components and upload it to quay.io"
+    echo ""
+    echo "Usage: ./build_release_image.sh [options] -u <quay.io username>"
+    echo "Options:"
+    echo "-h, --help      show this message"
+    echo "-u, --username  registered username in quay.io"    
+    echo "-t, --tag       push to a custom tag in your origin release image repo, default: latest"
+    echo "-r, --release   openshift release version, default: 4.9"
+    echo "-a, --auth      path of registry auth file, default: ./pull-secret.txt"
+    echo "--cccmo         custom cluster-cloud-controller-manager-operator image name, default: quay.io/openshift/origin-cluster-cloud-controller-manager-operator:$RELEASE"
+    echo "--aws-ccm       custom aws cloud-controller-manager image name, default: quay.io/openshift/origin-aws-cloud-controller-manager:$RELEASE"
+    echo "--azure-ccm     custom azure cloud-controller-manager image name, default: quay.io/openshift/origin-azure-cloud-controller-manager:$RELEASE"
+    echo "--azure-node    custom azure node manager image name, default: quay.io/openshift/origin-azure-cloud-node-manager:$RELEASE"
+    echo "--openstack-ccm custom openstack cloud-controller-manager image name, default: quay.io/openshift/origin-openstack-cloud-controller-manager:$RELEASE"
+    echo "--kapio         custom kube-apiserver-operator image name, default: current kube-apiserver-operator image from the release payload"
+    echo "--kcmo          custom kube-controller-manager-operator image name, default: current kube-controller-manager-operator image from the release payload"
+    echo "--mco           custom machine-config-operator image name, default: current machine-config-operator image from the release payload"
+}
+
+: ${GOPATH:=${HOME}/go}
+: ${TAG:="latest"}
+: ${RELEASE:="4.9"}
+: ${OC_REGISTRY_AUTH_FILE:="pull-secret.txt"}
+: ${CCCMO_IMAGE:="quay.io/openshift/origin-cluster-cloud-controller-manager-operator:$RELEASE"}
+: ${AWSCCM_IMAGE:="quay.io/openshift/origin-aws-cloud-controller-manager:$RELEASE"}
+: ${AZURECCM_IMAGE:="quay.io/openshift/origin-azure-cloud-controller-manager:$RELEASE"}
+: ${AZURENODE_IMAGE:="quay.io/openshift/origin-azure-cloud-node-manager:$RELEASE"}
+: ${OCCM_IMAGE:="quay.io/openshift/origin-openstack-cloud-controller-manager:$RELEASE"}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h|--help)
+            help
+            exit 0
+            ;;
+            
+        -u|--username)
+            USERNAME=$2
+            shift 2
+            ;;
+
+        -t|--tag)
+            TAG=$2
+            shift 2
+            ;;
+
+        -r|--release)
+            RELEASE=$2
+            shift 2
+            ;;
+
+        -a|--auth)
+            OC_REGISTRY_AUTH_FILE=$2
+            shift 2
+            ;;
+
+        --cccmo)
+            CCCMO_IMAGE=$2
+            shift 2
+            ;;
+
+        --aws-ccm)
+            AWSCCM_IMAGE=$2
+            shift 2
+            ;;
+
+        --azure-ccm)
+            AZURECCM_IMAGE=$2
+            shift 2
+            ;;
+
+        --azure-node)
+            AZURENODE_IMAGE=$2
+            shift 2
+            ;;
+
+        --openstack-ccm)
+            OCCM_IMAGE=$2
+            shift 2
+            ;;
+
+        --kapio)
+            KAPIO_IMAGE=$2
+            shift 2
+            ;;
+
+        --kcmo)
+            KCMO_IMAGE=$2
+            shift 2
+            ;;
+
+        --mco)
+            MCO_IMAGE=$2
+            shift 2
+            ;;
+
+        *)
+            echo "Invalid option $1"
+            help
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$USERNAME" ]; then
+    echo "-u/--username was not provided, exiting ..."
+    exit 1
+fi
+
+if [ ! -f "$OC_REGISTRY_AUTH_FILE" ]; then
+    echo "$OC_REGISTRY_AUTH_FILE not found, exiting ..."
+    exit 1
+fi
+
+echo "Creating local image registry at localhost:5000"
+docker rm -fi registry
+docker run -d -p 5000:5000 --restart=always --name registry docker.io/library/registry:2
+
+PREFIX="Pull From: "
+DEST_IMAGE="quay.io/$USERNAME/origin-release:$TAG"
+TEMP_IMAGE="localhost:5000/origin-release:$TAG"
+FROM_IMAGE=$(curl -s  https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp-dev-preview/latest-$RELEASE/release.txt | grep "$PREFIX" | sed -e "s/^$PREFIX//")
+
+echo "Start building local release image"
+
+oc adm release new \
+    --insecure=true \
+    --registry-config="$OC_REGISTRY_AUTH_FILE" \
+    --from-release="$FROM_IMAGE" \
+    --to-image="$TEMP_IMAGE" \
+    --server https://api.ci.openshift.org \
+    -n openshift \
+    cluster-cloud-controller-manager-operator=$CCCMO_IMAGE \
+    openstack-cloud-controller-manager=$OCCM_IMAGE \
+    aws-cloud-controller-manager=$AWSCCM_IMAGE \
+    azure-cloud-node-manager=$AZURENODE_IMAGE \
+    azure-cloud-controller-manager=$AZURECCM_IMAGE \
+    `[ ! -z "$KAPIO_IMAGE" ] && echo cluster-kube-apiserver-operator=$KAPIO_IMAGE` \
+    `[ ! -z "$KCMO_IMAGE" ] && echo cluster-kube-controller-manager-operator=$KCMO_IMAGE` \
+    `[ ! -z "$MCO_IMAGE" ] && echo machine-config-operator=$MCO_IMAGE`
+
+echo "The image has been created as $TEMP_IMAGE"
+
+docker pull $TEMP_IMAGE --tls-verify=false
+
+docker image tag $TEMP_IMAGE $DEST_IMAGE
+
+docker push $DEST_IMAGE
+
+echo "Successfully pushed $DEST_IMAGE"
+
+echo "Destroying the local registry"
+docker rm -fi registry
+
+echo "Testing release image"
+docker pull $DEST_IMAGE
+echo "$DEST_IMAGE image was tested, you can now deploy with the following command:"
+echo "OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE=$DEST_IMAGE openshift-install create cluster (...)"


### PR DESCRIPTION
1. build_operator_image.sh builds an image for an operator that contains your custrom changes, and then pushes the image in quay

2. build_release_image.sh builds a release image that contains info about the CCM operator and various CCMs.

For more information about how to use the scripts read the README.md