### PR TITLE
Update component name in Owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,4 +7,5 @@ approvers:
   - elmiko
   - lobziik
 
-component: "cloud-controller-manager"
+component: "Cloud Compute"
+subcomponent: "Cloud Controller Manager"


### PR DESCRIPTION
There is no such registered component as "cloud-controller-manager".
It should be:

component: "Cloud Compute"
subcomponent: "Cloud Controller Manager"