### PR TITLE
Ensure AWS CCM is using leader election in openshift-cloud-controller-manager namespace

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -22,6 +22,7 @@ spec:
       - args:
         - --cloud-provider=aws
         - --use-service-account-credentials=true
+        - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - -v=2
         image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.19.0-alpha.1
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
By default CCM configuration is using `kube-system` namespace, which is not something we should allow.