### PR TITLE
add object names to the substitution logs

### DIFF
--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -21,7 +21,7 @@ func setDeploymentImages(config config.OperatorConfig, d *v1.Deployment) {
 			continue
 		}
 
-		klog.Infof("Substituting %q in %q with %s", container.Name, d.Kind, config.ControllerImage)
+		klog.Infof("Substituting %q in Deployment %q with %s", container.Name, d.Name, config.ControllerImage)
 		d.Spec.Template.Spec.Containers[i].Image = config.ControllerImage
 	}
 }
@@ -32,7 +32,7 @@ func setDaemonSetImage(config config.OperatorConfig, d *v1.DaemonSet) {
 			continue
 		}
 
-		klog.Infof("Substituting %q in %q with %s", container.Name, d.Kind, config.ControllerImage)
+		klog.Infof("Substituting %q in DaemonSet %q with %s", container.Name, d.Name, config.ControllerImage)
 		d.Spec.Template.Spec.Containers[i].Image = config.CloudNodeImage
 	}
 }


### PR DESCRIPTION
This change add the object name to the logs produced when doing a
substitution on a Deployment or DaemonSet. The kind of the resource has
been removed from the formatted fields and added directly into the log
statement.

without this PR, the logs for this code look like this:
```
I0621 19:20:34.823544       1 substitution.go:24] Substituting "cloud-controller-manager" in "Deployment" with registry.ci.openshift.org/ocp/4.9-2021-06-19-105001@sha256:a86c73704f2709692a19d67b8eea82bcf8166f82334e659fbbe828be81e306d5
```
after this PR it would look like this
```
I0621 19:20:34.823544       1 substitution.go:24] Substituting "cloud-controller-manager" in Deployment "aws-cloud-controller-manager" with registry.ci.openshift.org/ocp/4.9-2021-06-19-105001@sha256:a86c73704f2709692a19d67b8eea82bcf8166f82334e659fbbe828be81e306d5
```
There are multiple log lines in the operator output when the substitution happens, i think adding the name of the object will help people to figure what resource has been changed.