### PR TITLE
Enable errcheck linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,9 @@ vet:
 	go vet ./...
 
 # Run golangci-lint against code
-# TODO: fix errors and enable errcheck
 .PHONY: lint
 lint: golangci-lint
-	( GOLANGCI_LINT_CACHE=$(PROJECT_DIR)/.cache $(GOLANGCI_LINT) run --timeout 10m --disable errcheck )
+	( GOLANGCI_LINT_CACHE=$(PROJECT_DIR)/.cache $(GOLANGCI_LINT) run --timeout 10m )
 
 # Run go mod
 .PHONY: vendor

--- a/cmd/cluster-cloud-controller-manager-operator/main.go
+++ b/cmd/cluster-cloud-controller-manager-operator/main.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 func main() {
-	flag.Set("logtostderr", "true")
+	flag.Set("logtostderr", "true") //nolint:errcheck
 	klog.InitFlags(nil)
 
 	metricsAddr := flag.String(

--- a/pkg/controllers/suite_test.go
+++ b/pkg/controllers/suite_test.go
@@ -41,8 +41,12 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 func init() {
-	configv1.Install(scheme.Scheme)
-	v1.AddToScheme(scheme.Scheme)
+	if err := configv1.Install(scheme.Scheme); err != nil {
+		panic(err)
+	}
+	if err := v1.AddToScheme(scheme.Scheme); err != nil {
+		panic(err)
+	}
 }
 
 const (


### PR DESCRIPTION
This commit enables `errcheck` linter for golangci-lint and additionally corrects all cases pointed out by the linter.