### PR TITLE
Add an OpenStack bootstrap static pod manifest

### DIFF
--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -40,6 +40,8 @@ func GetBootstrapResources(platform configv1.PlatformType) []client.Object {
 		return aws.GetBootstrapResources()
 	case configv1.AzurePlatformType:
 		return azure.GetBootstrapResources()
+	case configv1.OpenStackPlatformType:
+		return openstack.GetBootstrapResources()
 	default:
 		klog.Warning("No recognized cloud provider platform found in infrastructure")
 		return nil

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -83,8 +83,9 @@ func TestGetBootstrapResources(t *testing.T) {
 		platform: configv1.AWSPlatformType,
 		expected: aws.GetBootstrapResources(),
 	}, {
-		name:     "OpenStack resources are empty, as the platform is not yet supported",
+		name:     "OpenStack resources returned as expected",
 		platform: configv1.OpenStackPlatformType,
+		expected: openstack.GetBootstrapResources(),
 	}, {
 		name:     "GCP resources are empty, as the platform is not yet supported",
 		platform: configv1.GCPPlatformType,

--- a/pkg/cloud/openstack/bootstrap/pod.yaml
+++ b/pkg/cloud/openstack/bootstrap/pod.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: openstack-cloud-controller-manager
+  namespace: kube-system
+spec:
+  priorityClassName: system-cluster-critical
+  containers:
+  - args:
+    - --cloud-provider=openstack
+    - --use-service-account-credentials=false
+    - --controllers=cloud-node # run only cloud-node controller required to bootstrap master nodes
+    - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
+    - --leader-elect=false
+    - -v=2
+    image: quay.io/openshift/origin-openstack-cloud-controller-manager
+    imagePullPolicy: IfNotPresent
+    name: cloud-controller-manager
+    volumeMounts:
+    - mountPath: /etc/kubernetes/secrets
+      name: secrets
+      readOnly: true
+  hostNetwork: true
+  volumes:
+  - hostPath:
+      path: /etc/kubernetes/bootstrap-secrets
+    name: secrets

--- a/pkg/cloud/openstack/openstack.go
+++ b/pkg/cloud/openstack/openstack.go
@@ -11,18 +11,24 @@ import (
 )
 
 var (
-	//go:embed assets/*
+	//go:embed assets/* bootstrap/*
 	openStackFS      embed.FS
 	openStackSources = []common.ObjectSource{
 		{Object: &v1.ConfigMap{}, Path: "assets/config.yaml"},
 		{Object: &appsv1.Deployment{}, Path: "assets/deployment.yaml"},
 	}
-	openStackResources []client.Object
+	openstackBootstrapSources = []common.ObjectSource{
+		{Object: &v1.Pod{}, Path: "bootstrap/pod.yaml"},
+	}
+	openStackResources          []client.Object
+	openStackBootstrapResources []client.Object
 )
 
 func init() {
 	var err error
 	openStackResources, err = common.ReadResources(openStackFS, openStackSources)
+	utilruntime.Must(err)
+	openStackBootstrapResources, err = common.ReadResources(openStackFS, openstackBootstrapSources)
 	utilruntime.Must(err)
 }
 
@@ -31,6 +37,16 @@ func GetResources() []client.Object {
 	resources := make([]client.Object, len(openStackResources))
 	for i := range openStackResources {
 		resources[i] = openStackResources[i].DeepCopyObject().(client.Object)
+	}
+
+	return resources
+}
+
+// GetBootstrapResources returns a list static pods for provisioning CCM on bootstrap node for AWS
+func GetBootstrapResources() []client.Object {
+	resources := make([]client.Object, len(openStackBootstrapResources))
+	for i := range openStackBootstrapResources {
+		resources[i] = openStackBootstrapResources[i].DeepCopyObject().(client.Object)
 	}
 
 	return resources

--- a/pkg/cloud/openstack/openstack_test.go
+++ b/pkg/cloud/openstack/openstack_test.go
@@ -21,5 +21,18 @@ func TestGetResources(t *testing.T) {
 
 	assert.Contains(t, kinds, "Deployment")
 	assert.Contains(t, kinds, "ConfigMap")
+}
 
+func TestGetBootstrapResources(t *testing.T) {
+	resources := GetBootstrapResources()
+	assert.Len(t, resources, 1)
+
+	var names, kinds []string
+	for _, r := range resources {
+		names = append(names, r.GetName())
+		kinds = append(kinds, r.GetObjectKind().GroupVersionKind().Kind)
+	}
+
+	assert.Contains(t, names, "openstack-cloud-controller-manager")
+	assert.Contains(t, kinds, "Pod")
 }


### PR DESCRIPTION
It will be used to provision a node controller on the bootstrap node to register masters.