### PR TITLE
Use upstream openshift images from quay.io

### DIFF
--- a/docs/dev/cloud-provider-integration.md
+++ b/docs/dev/cloud-provider-integration.md
@@ -188,7 +188,7 @@ You should add your cloud provider image reference tag to the list. The list is 
 - name: aws-cloud-controller-manager
   from:
    kind: DockerImage
-   name: registry.ci.openshift.org/openshift:aws-cloud-controller-manager
+   name: quay.io/openshift/origin-aws-cloud-controller-manager
 ```
 
 You will have to extend the config [images](https://github.com/openshift/cluster-cloud-controller-manager-operator/blob/master/manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml) list with image name:
@@ -202,7 +202,7 @@ metadata:
 data:
  images.json: >
    {
-     "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+     "cloudControllerManagerAWS": "quay.io/openshift/origin-aws-cloud-controller-manager",
    … # Other images 
    }
 ```

--- a/docs/dev/hacking-guide.md
+++ b/docs/dev/hacking-guide.md
@@ -72,8 +72,8 @@ metadata:
 data:
   images.json: |
     {
-      "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
-      "cloudControllerManagerOpenStack": "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager"
+      "cloudControllerManagerAWS": "quay.io/openshift/origin-aws-cloud-controller-manager",
+      "cloudControllerManagerOpenStack": "quay.io/openshift/origin-openstack-cloud-controller-manager"
     }
 ```
 

--- a/hack/example-images.json
+++ b/hack/example-images.json
@@ -1,4 +1,4 @@
 {
-    "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
-    "cloudControllerManagerOpenStack": "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager"
+    "cloudControllerManagerAWS": "quay.io/openshift/origin-aws-cloud-controller-manager",
+    "cloudControllerManagerOpenStack": "quay.io/openshift/origin-openstack-cloud-controller-manager"
 }

--- a/manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml
@@ -9,8 +9,8 @@ metadata:
 data:
   images.json: >
     {
-      "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
-      "cloudControllerManagerAzure": "registry.ci.openshift.org/openshift:azure-cloud-controller-manager",
-      "cloudNodeManagerAzure": "registry.ci.openshift.org/openshift:azure-cloud-node-manager",
-      "cloudControllerManagerOpenStack": "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager"
+      "cloudControllerManagerAWS": "quay.io/openshift/origin-aws-cloud-controller-manager",
+      "cloudControllerManagerAzure": "quay.io/openshift/origin-azure-cloud-controller-manager",
+      "cloudNodeManagerAzure": "quay.io/openshift/origin-azure-cloud-node-manager",
+      "cloudControllerManagerOpenStack": "quay.io/openshift/origin-openstack-cloud-controller-manager"
     }

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: cluster-cloud-controller-manager
       containers:
       - name: cluster-cloud-controller-manager
-        image: registry.ci.openshift.org/openshift:cluster-cloud-controller-manager-operator
+        image: quay.io/openshift/origin-cluster-cloud-controller-manager-operator
         command:
         - "/cluster-controller-manager-operator"
         args:

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,20 +5,20 @@ spec:
   - name: cluster-cloud-controller-manager-operator
     from:
       kind: DockerImage
-      name: registry.ci.openshift.org/openshift:cluster-cloud-controller-manager-operator
+      name: quay.io/openshift/origin-cluster-cloud-controller-manager-operator
   - name: aws-cloud-controller-manager
     from:
       kind: DockerImage
-      name: registry.ci.openshift.org/openshift:aws-cloud-controller-manager
+      name: quay.io/openshift/origin-aws-cloud-controller-manager
   - name: azure-cloud-controller-manager
     from:
       kind: DockerImage
-      name: registry.ci.openshift.org/openshift:azure-cloud-controller-manager
+      name: quay.io/openshift/origin-azure-cloud-controller-manager
   - name: azure-cloud-node-manager
     from:
       kind: DockerImage
-      name: registry.ci.openshift.org/openshift:azure-cloud-node-manager
+      name: quay.io/openshift/origin-azure-cloud-node-manager
   - name: openstack-cloud-controller-manager
     from:
       kind: DockerImage
-      name: registry.ci.openshift.org/openshift:openstack-cloud-controller-manager
+      name: quay.io/openshift/origin-openstack-cloud-controller-manager

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - --use-service-account-credentials=true
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - -v=2
-        image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.19.0-alpha.1
+        image: quay.io/openshift/origin-aws-cloud-controller-manager
         imagePullPolicy: IfNotPresent
         name: cloud-controller-manager
         resources:

--- a/pkg/cloud/aws/bootstrap/pod.yaml
+++ b/pkg/cloud/aws/bootstrap/pod.yaml
@@ -13,7 +13,7 @@ spec:
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     - --leader-elect=false
     - -v=2
-    image: gcr.io/k8s-staging-provider-aws/cloud-controller-manager:v1.19.0-alpha.1
+    image: quay.io/openshift/origin-aws-cloud-controller-manager
     imagePullPolicy: IfNotPresent
     name: cloud-controller-manager
     volumeMounts:

--- a/pkg/cloud/azure/bootstrap/pod.yaml
+++ b/pkg/cloud/azure/bootstrap/pod.yaml
@@ -8,7 +8,7 @@ spec:
   hostNetwork: true
   containers:
     - name: cloud-controller-manager
-      image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.0.0
+      image: quay.io/openshift/origin-azure-cloud-controller-manager
       imagePullPolicy: IfNotPresent
       command: ["cloud-controller-manager"]
       args:

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -42,7 +42,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cloud-controller-manager
-          image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:latest
+          image: quay.io/openshift/origin-openstack-cloud-controller-manager
           imagePullPolicy: "IfNotPresent"
           env:
             - name: CLOUD_CONFIG

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	timeout            = time.Second * 10
-	testImagesFilePath = "../../hack/example-images.json"
+	testImagesFilePath = "./fixtures/images.json"
 )
 
 var _ = Describe("Cluster Operator status controller", func() {

--- a/pkg/controllers/fixtures/images.json
+++ b/pkg/controllers/fixtures/images.json
@@ -1,0 +1,4 @@
+{
+    "cloudControllerManagerAWS": "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+    "cloudControllerManagerOpenStack": "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager"
+}


### PR DESCRIPTION
Instead of using images from third-party registries and our CI registry, it's better to provide links to upstream images from quay.io