### PR TITLE
Run CCCMO and CCM components before CNI

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -26,7 +26,17 @@ spec:
       - name: cluster-cloud-controller-manager
         image: quay.io/openshift/origin-cluster-cloud-controller-manager-operator
         command:
-        - "/cluster-controller-manager-operator"
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -o allexport
+          if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
+            source /etc/kubernetes/apiserver-url.env
+          else
+            URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
+          fi
+          exec /cluster-controller-manager-operator
         args:
         - --leader-elect
         - "--images-json=/etc/cloud-controller-manager-config/images.json"
@@ -40,6 +50,10 @@ spec:
         volumeMounts:
         - name: images
           mountPath: /etc/cloud-controller-manager-config/
+        - mountPath: /etc/kubernetes
+          name: host-etc-kube
+          readOnly: true
+      hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
       restartPolicy: Always
@@ -58,8 +72,20 @@ spec:
         operator: "Exists"
         effect: "NoExecute"
         tolerationSeconds: 120
+      - key: "node.cloudprovider.kubernetes.io/uninitialized"
+        operator: "Exists"
+        effect: "NoSchedule"
+        # CNI relies on CCM to fill in IP information on Node objects.
+        # Therefore we must schedule before the CNI can mark the Node as ready.
+      - key: "node.kubernetes.io/not-ready"
+        operator: "Exists"
+        effect: "NoSchedule"
       volumes:
       - name: images
         configMap:
           defaultMode: 420
           name: cloud-controller-manager-images
+      - name: host-etc-kube
+        hostPath:
+          path: /etc/kubernetes
+          type: Directory

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -24,6 +24,18 @@ spec:
         - --use-service-account-credentials=true
         - --leader-elect-resource-namespace=openshift-cloud-controller-manager
         - -v=2
+        command:
+        - /bin/bash
+        - -c
+        - |
+          #!/bin/bash
+          set -o allexport
+          if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
+            source /etc/kubernetes/apiserver-url.env
+          else
+            URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
+          fi
+          exec /bin/aws-cloud-controller-manager
         image: quay.io/openshift/origin-aws-cloud-controller-manager
         imagePullPolicy: IfNotPresent
         name: cloud-controller-manager
@@ -31,6 +43,10 @@ spec:
           requests:
             cpu: 200m
             memory: 50Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes
+          name: host-etc-kube
+          readOnly: true
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -58,4 +74,12 @@ spec:
         tolerationSeconds: 120
       - effect: NoSchedule
         key: node.cloudprovider.kubernetes.io/uninitialized
-        value: "true"
+        operator: Exists
+      - effect: NoSchedule
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+      volumes:
+      - name: host-etc-kube
+        hostPath:
+          path: /etc/kubernetes
+          type: Directory

--- a/pkg/cloud/aws/bootstrap/pod.yaml
+++ b/pkg/cloud/aws/bootstrap/pod.yaml
@@ -10,18 +10,38 @@ spec:
     - --cloud-provider=aws
     - --use-service-account-credentials=false
     - --controllers=cloud-node # run only cloud-node controller required to bootstrap master nodes
-    - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
+    - --kubeconfig=/etc/kubernetes/bootstrap-secrets/kubeconfig
     - --leader-elect=false
     - -v=2
+    command:
+    - /bin/bash
+    - -c
+    - |
+      #!/bin/bash
+      set -o allexport
+      if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
+        source /etc/kubernetes/apiserver-url.env
+      else
+        URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
+      fi
+      exec /bin/aws-cloud-controller-manager
     image: quay.io/openshift/origin-aws-cloud-controller-manager
     imagePullPolicy: IfNotPresent
     name: cloud-controller-manager
     volumeMounts:
-    - mountPath: /etc/kubernetes/secrets
-      name: secrets
+    - mountPath: /etc/kubernetes
+      name: host-etc-kube
       readOnly: true
   hostNetwork: true
+  tolerations:
+  - effect: NoSchedule
+    key: node.cloudprovider.kubernetes.io/uninitialized
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/not-ready
+    operator: Exists
   volumes:
-  - hostPath:
-      path: /etc/kubernetes/bootstrap-secrets
-    name: secrets
+  - name: host-etc-kube
+    hostPath:
+      path: /etc/kubernetes
+      type: Directory

--- a/pkg/cloud/azure/bootstrap/pod.yaml
+++ b/pkg/cloud/azure/bootstrap/pod.yaml
@@ -10,12 +10,23 @@ spec:
     - name: cloud-controller-manager
       image: quay.io/openshift/origin-azure-cloud-controller-manager
       imagePullPolicy: IfNotPresent
-      command: ["cloud-controller-manager"]
+      command:
+      - /bin/bash
+      - -c
+      - |
+        #!/bin/bash
+        set -o allexport
+        if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
+          source /etc/kubernetes/apiserver-url.env
+        else
+          URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
+        fi
+        exec cloud-controller-manager
       args:
         - --cloud-provider=azure
         - --controllers=cloud-node # run cloud-node controller only for Node initialization
-        - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
-        - --cloud-config=/etc/kubernetes/configs/cloud.conf
+        - --kubeconfig=/etc/kubernetes/bootstrap-secrets/kubeconfig
+        - --cloud-config=/etc/kubernetes/bootstrap-configs/cloud.conf
         - --leader-elect=false
         - --port=10267
         - -v=2
@@ -27,14 +38,18 @@ spec:
         periodSeconds: 10
         timeoutSeconds: 5
       volumeMounts:
-      - name: secrets
-        mountPath: /etc/kubernetes/secrets
-      - name: configs
-        mountPath: /etc/kubernetes/configs
+      - mountPath: /etc/kubernetes
+        name: host-etc-kube
+        readOnly: true
+  tolerations:
+  - effect: NoSchedule
+    key: node.cloudprovider.kubernetes.io/uninitialized
+    operator: Exists
+  - effect: NoSchedule
+    key: node.kubernetes.io/not-ready
+    operator: Exists
   volumes:
-  - name: secrets
+  - name: host-etc-kube
     hostPath:
-      path: /etc/kubernetes/bootstrap-secrets
-  - name: configs
-    hostPath:
-      path: /etc/kubernetes/bootstrap-configs
+      path: /etc/kubernetes
+      type: Directory

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -1,6 +1,7 @@
 package cloud
 
 import (
+	"strings"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -8,6 +9,8 @@ import (
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/azure"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/openstack"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -134,5 +137,122 @@ func TestGetBootstrapResources(t *testing.T) {
 				assert.NotEqualValues(t, resources, newResources)
 			}
 		})
+	}
+}
+
+func TestResourcesRunBeforeCNI(t *testing.T) {
+	/*
+		As CNI relies on CMM to initialist the Node IP addresses. We must ensure
+		that CCM pods can run before the CNO has been deployed and before the CNI
+		initialises the Node.
+
+		To achieve this, we must tolerate the not-ready taint, use host
+		networking and use the internal API Load Balancer instead of the API Service.
+	*/
+
+	platforms := []configv1.PlatformType{
+		configv1.AWSPlatformType,
+		configv1.OpenStackPlatformType,
+		configv1.GCPPlatformType,
+		configv1.AzurePlatformType,
+		configv1.VSpherePlatformType,
+		configv1.OvirtPlatformType,
+		configv1.IBMCloudPlatformType,
+		configv1.LibvirtPlatformType,
+		configv1.KubevirtPlatformType,
+		configv1.BareMetalPlatformType,
+		configv1.NonePlatformType,
+	}
+	for _, platform := range platforms {
+		t.Run(string(platform), func(t *testing.T) {
+			resources := GetResources(platform)
+			resources = append(resources, GetBootstrapResources(platform)...)
+
+			for _, resource := range resources {
+				switch obj := resource.(type) {
+				case *corev1.Pod:
+					checkResourceRunsBeforeCNI(t, obj.Spec)
+				case *appsv1.Deployment:
+					checkResourceRunsBeforeCNI(t, obj.Spec.Template.Spec)
+				case *appsv1.DaemonSet:
+					checkResourceRunsBeforeCNI(t, obj.Spec.Template.Spec)
+				default:
+					// Nothing to check for non
+				}
+			}
+		})
+	}
+}
+
+func checkResourceRunsBeforeCNI(t *testing.T, podSpec corev1.PodSpec) {
+	checkResourceTolerations(t, podSpec)
+	checkHostNetwork(t, podSpec)
+	checkVolumes(t, podSpec)
+	checkContainerCommand(t, podSpec)
+}
+
+func checkResourceTolerations(t *testing.T, podSpec corev1.PodSpec) {
+	uninitializedTaint := corev1.Toleration{
+		Key:      "node.cloudprovider.kubernetes.io/uninitialized",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+	notReadyTaint := corev1.Toleration{
+		Key:      "node.kubernetes.io/not-ready",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
+
+	tolerations := podSpec.Tolerations
+	assert.Contains(t, tolerations, uninitializedTaint, "PodSpec should tolerate the uninitialized taint")
+	assert.Contains(t, tolerations, notReadyTaint, "PodSpec should tolerate the not-ready taint")
+}
+
+func checkHostNetwork(t *testing.T, podSpec corev1.PodSpec) {
+	assert.Equal(t, podSpec.HostNetwork, true, "PodSpec should set HostNetwork true")
+}
+
+func checkVolumes(t *testing.T, podSpec corev1.PodSpec) {
+	directory := corev1.HostPathDirectory
+	hostVolume := corev1.Volume{
+		Name: "host-etc-kube",
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: "/etc/kubernetes",
+				Type: &directory,
+			},
+		},
+	}
+	hostVolumeMount := corev1.VolumeMount{
+		MountPath: "/etc/kubernetes",
+		Name:      "host-etc-kube",
+		ReadOnly:  true,
+	}
+
+	assert.Contains(t, podSpec.Volumes, hostVolume, "PodSpec Volumes should contain host-etc-kube host path volume")
+
+	for _, container := range podSpec.Containers {
+		assert.Contains(t, container.VolumeMounts, hostVolumeMount, "Container VolumeMounts should contain host-etc-kube volume mount")
+	}
+}
+
+func checkContainerCommand(t *testing.T, podSpec corev1.PodSpec) {
+	binBash := "/bin/bash"
+	dashC := "-c"
+	setAPIEnv := `#!/bin/bash
+set -o allexport
+if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
+  source /etc/kubernetes/apiserver-url.env
+else
+  URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
+fi
+exec `
+
+	for _, container := range podSpec.Containers {
+		command := container.Command
+		assert.Len(t, command, 3, "Container Command should have 3 elements")
+		assert.Equal(t, command[0], binBash, "Container Command first element should equal %q", binBash)
+		assert.Equal(t, command[1], dashC, "Container Command second element should equal %q", dashC)
+		assert.True(t, strings.HasPrefix(command[2], setAPIEnv), "Container Command third (%q) element should start with %q", command[2], setAPIEnv)
 	}
 }

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -38,7 +38,10 @@ spec:
           operator: Exists
           effect: "NoSchedule"
         - key: node.cloudprovider.kubernetes.io/uninitialized
-          value: "true"
+          operator: Exists
+          effect: NoSchedule
+        - key: node.kubernetes.io/not-ready
+          operator: Exists
           effect: NoSchedule
       containers:
         - name: cloud-controller-manager
@@ -48,18 +51,32 @@ spec:
             - name: CLOUD_CONFIG
               value: /etc/kubernetes/config/cloud.conf
           args:
-            - /bin/openstack-cloud-controller-manager
             - --v=1
             - --cloud-config=$(CLOUD_CONFIG)
             - --cloud-provider=openstack
             - --use-service-account-credentials=true
             - --bind-address=127.0.0.1
             - --leader-elect-resource-namespace=openshift-cloud-controller-manager
+          command:
+          - /bin/bash
+          - -c
+          - |
+            #!/bin/bash
+            set -o allexport
+            if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
+              source /etc/kubernetes/apiserver-url.env
+            else
+              URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
+            fi
+            exec /bin/openstack-cloud-controller-manager
           resources:
             requests:
               cpu: 200m
               memory: 50Mi
           volumeMounts:
+            - mountPath: /etc/kubernetes
+              name: host-etc-kube
+              readOnly: true
             - name: secret-occm
               mountPath: /etc/kubernetes/secret
               readOnly: true
@@ -67,6 +84,10 @@ spec:
               mountPath: /etc/kubernetes/config
               readOnly: true
       volumes:
+        - name: host-etc-kube
+          hostPath:
+            path: /etc/kubernetes
+            type: Directory
         - name: secret-occm
           secret:
             secretName: openstack-cloud-credentials


### PR DESCRIPTION
As CNI relies on CMM to initialist the Node IP addresses. We must ensure  that CCCMO can set up and reconfigure if necesssary the CCM pods before  the CNO has been deployed and before the CNI initialises the Node.

To achieve this, we must tolerate the not-ready taint, use host networking and use the internal API Load Balancer instead of the API Service.

Full motivation for why we need to do this can be found in this doc (RH Internal) https://docs.google.com/document/d/1yAczhHNJ4rDqVFFvyi7AZ27DEQdvx8DmLNbavIjrjn0/edit?ts=60de093f