### PR TITLE
Add .cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 # Directories with variable content
 bin/*
 config/*
+
+# golangci-lint cache
+.cache/*


### PR DESCRIPTION
This folder is generated by golangci-lint, and contains its cache.