### PR TITLE
Allow the operator to list deployments in config namespaces

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
@@ -107,6 +107,14 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - get
+      - list
+      - watch
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -140,6 +148,14 @@ rules:
       - ""
     resources:
       - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
     verbs:
       - get
       - list


### PR DESCRIPTION
Now CCCMO fails because it can list deployments in "openshift-config" and "openshift-config-managed" namespaces.

```txt
E0705 11:26:19.089134       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:241: Failed to watch *v1.Deployment: failed to list *v1.Deployment: deployments.apps is forbidden: User "system:serviceaccount:openshift-cloud-controller-manager-operator:cluster-cloud-controller-manager" cannot list resource "deployments" in API group "apps" in the namespace "openshift-config"
```

To prevent this, we add required rules to "cluster-cloud-controller-manager" roles in the related namespaces.