### PR TITLE
Use /etc/openstack to mount the config and secrets

### DIFF
--- a/pkg/cloud/openstack/assets/config.yaml
+++ b/pkg/cloud/openstack/assets/config.yaml
@@ -3,7 +3,7 @@ data:
   cloud.conf: |
     [Global]
     use-clouds = true
-    clouds-file = /etc/kubernetes/secret/clouds.yaml
+    clouds-file = /etc/openstack/secret/clouds.yaml
     cloud = openstack
 kind: ConfigMap
 metadata:

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -68,7 +68,7 @@ spec:
             else
               URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
             fi
-            exec /bin/openstack-cloud-controller-manager
+            exec /usr/bin/openstack-cloud-controller-manager
           resources:
             requests:
               cpu: 200m

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -49,7 +49,7 @@ spec:
           imagePullPolicy: "IfNotPresent"
           env:
             - name: CLOUD_CONFIG
-              value: /etc/kubernetes/config/cloud.conf
+              value: /etc/openstack/config/cloud.conf
           args:
             - --v=1
             - --cloud-config=$(CLOUD_CONFIG)
@@ -78,10 +78,10 @@ spec:
               name: host-etc-kube
               readOnly: true
             - name: secret-occm
-              mountPath: /etc/kubernetes/secret
+              mountPath: /etc/openstack/secret
               readOnly: true
             - name: config-occm
-              mountPath: /etc/kubernetes/config
+              mountPath: /etc/openstack/config
               readOnly: true
       volumes:
         - name: host-etc-kube


### PR DESCRIPTION
After #76 `/etc/kubernetes` is a read-only fs, so we can't create folders there.

```txt
  Normal   Pulled     0s (x3 over 24s)  kubelet            Container image "quay.io/openshift/origin-openstack-cloud-controller-manager:4.9" already present on machine
  Warning  Failed     0s                kubelet            Error: container create failed: time="2021-07-05T13:36:15Z" level=error msg="container_linux.go:367: starting container process caused: process_linux.go:495: container init caused: rootfs_linux.go:76: mounting \"/var/lib/kubelet/pods/7b2ade72-eb8b-49be-8f33-ce8a9c43d7b3/volumes/kubernetes.io~secret/secret-occm\" to rootfs at \"/etc/kubernetes/secret\" caused: mkdir /var/lib/containers/storage/overlay/5f06245b3bfd93c0c9b446484b6a918d80e1e63fa06b6e8339f157ddf41e5357/merged/etc/kubernetes/secret: read-only file system"
```

To avoid this, we will mount openstack related resources to /etc/openstack.

Additionally this PR fixes OpenStack CCM binary path in the deployment. According to https://github.com/openshift/cloud-provider-openstack/blob/master/images/cloud-controller-manager/Dockerfile#L10 it is `/usr/bin/openstack-cloud-controller-manager` and not `/bin/openstack-cloud-controller-manager`.