### PR TITLE
Allow CCMs to create serviceaccounts/token

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_03_rbac_provider.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_03_rbac_provider.yaml
@@ -112,6 +112,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - serviceaccounts/token
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - persistentvolumes
   verbs:
   - get


### PR DESCRIPTION
The issue was found recently with OpenStack CCM:
https://github.com/kubernetes/cloud-provider-openstack/issues/1514

```txt
W0705 21:33:42.494088       1 client_builder_dynamic.go:207] get token failed: serviceaccounts "node-controller" is forbidden: User "system:serviceaccount:openshift-cloud-controller-manager:cloud-controller-manager" cannot create resource "serviceaccounts/token" in API group "" in the namespace "kube-system"
```

To fix it we need to add a rule that allows CCMs to create SA tokens:
https://github.com/kubernetes/cloud-provider-openstack/pull/1521