### PR TITLE
Inline container args into command

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -36,10 +36,9 @@ spec:
           else
             URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
           fi
-          exec /cluster-controller-manager-operator
-        args:
-        - --leader-elect
-        - "--images-json=/etc/cloud-controller-manager-config/images.json"
+          exec /cluster-controller-manager-operator \
+          --leader-elect \
+          "--images-json=/etc/cloud-controller-manager-config/images.json"
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -19,12 +19,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       containers:
-      - args:
-        - --cloud-provider=aws
-        - --use-service-account-credentials=true
-        - --leader-elect-resource-namespace=openshift-cloud-controller-manager
-        - -v=2
-        command:
+      - command:
         - /bin/bash
         - -c
         - |
@@ -35,7 +30,11 @@ spec:
           else
             URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
           fi
-          exec /bin/aws-cloud-controller-manager
+          exec /bin/aws-cloud-controller-manager \
+          --cloud-provider=aws \
+          --use-service-account-credentials=true \
+          --leader-elect-resource-namespace=openshift-cloud-controller-manager \
+          -v=2
         image: quay.io/openshift/origin-aws-cloud-controller-manager
         imagePullPolicy: IfNotPresent
         name: cloud-controller-manager

--- a/pkg/cloud/aws/bootstrap/pod.yaml
+++ b/pkg/cloud/aws/bootstrap/pod.yaml
@@ -6,14 +6,7 @@ metadata:
 spec:
   priorityClassName: system-cluster-critical
   containers:
-  - args:
-    - --cloud-provider=aws
-    - --use-service-account-credentials=false
-    - --controllers=cloud-node # run only cloud-node controller required to bootstrap master nodes
-    - --kubeconfig=/etc/kubernetes/bootstrap-secrets/kubeconfig
-    - --leader-elect=false
-    - -v=2
-    command:
+  - command:
     - /bin/bash
     - -c
     - |
@@ -24,7 +17,13 @@ spec:
       else
         URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
       fi
-      exec /bin/aws-cloud-controller-manager
+      exec /bin/aws-cloud-controller-manager \
+      --cloud-provider=aws \
+      --use-service-account-credentials=false \
+      --controllers=cloud-node \
+      --kubeconfig=/etc/kubernetes/bootstrap-secrets/kubeconfig \
+      --leader-elect=false \
+      -v=2
     image: quay.io/openshift/origin-aws-cloud-controller-manager
     imagePullPolicy: IfNotPresent
     name: cloud-controller-manager

--- a/pkg/cloud/azure/bootstrap/pod.yaml
+++ b/pkg/cloud/azure/bootstrap/pod.yaml
@@ -21,15 +21,14 @@ spec:
         else
           URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
         fi
-        exec cloud-controller-manager
-      args:
-        - --cloud-provider=azure
-        - --controllers=cloud-node # run cloud-node controller only for Node initialization
-        - --kubeconfig=/etc/kubernetes/bootstrap-secrets/kubeconfig
-        - --cloud-config=/etc/kubernetes/bootstrap-configs/cloud.conf
-        - --leader-elect=false
-        - --port=10267
-        - -v=2
+        exec cloud-controller-manager \
+        --cloud-provider=azure \
+        --controllers=cloud-node \
+        --kubeconfig=/etc/kubernetes/bootstrap-secrets/kubeconfig \
+        --cloud-config=/etc/kubernetes/bootstrap-configs/cloud.conf \
+        --leader-elect=false \
+        --port=10267 \
+        -v=2
       livenessProbe:
         httpGet:
           path: /healthz

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -251,6 +251,8 @@ exec `
 	for _, container := range podSpec.Containers {
 		command := container.Command
 		assert.Len(t, command, 3, "Container Command should have 3 elements")
+		assert.Len(t, container.Args, 0, "Container Args should have no elements, inline the args into the Container Command")
+
 		assert.Equal(t, command[0], binBash, "Container Command first element should equal %q", binBash)
 		assert.Equal(t, command[1], dashC, "Container Command second element should equal %q", dashC)
 		assert.True(t, strings.HasPrefix(command[2], setAPIEnv), "Container Command third (%q) element should start with %q", command[2], setAPIEnv)

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -50,13 +50,6 @@ spec:
           env:
             - name: CLOUD_CONFIG
               value: /etc/openstack/config/cloud.conf
-          args:
-            - --v=1
-            - --cloud-config=$(CLOUD_CONFIG)
-            - --cloud-provider=openstack
-            - --use-service-account-credentials=true
-            - --bind-address=127.0.0.1
-            - --leader-elect-resource-namespace=openshift-cloud-controller-manager
           command:
           - /bin/bash
           - -c
@@ -68,7 +61,13 @@ spec:
             else
               URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
             fi
-            exec /usr/bin/openstack-cloud-controller-manager
+            exec /usr/bin/openstack-cloud-controller-manager \
+            --v=1 \
+            --cloud-config=$(CLOUD_CONFIG) \
+            --cloud-provider=openstack \
+            --use-service-account-credentials=true \
+            --bind-address=127.0.0.1 \
+            --leader-elect-resource-namespace=openshift-cloud-controller-manager
           resources:
             requests:
               cpu: 200m


### PR DESCRIPTION
Because we are now using the script to set the environment, args weren't being passed through correctly. To resolve that, lets just inline them and ensure that the args are always inlined going forward

CC @Fedosin As you found the issue in your testing