### PR TITLE
Prevent CCMs to be on the same node

### DIFF
--- a/docs/dev/cloud-provider-integration.md
+++ b/docs/dev/cloud-provider-integration.md
@@ -137,13 +137,11 @@ spec:
      # different Nodes you need to set affinity settings
      affinity:
        podAntiAffinity:
-         preferredDuringSchedulingIgnoredDuringExecution:
-         - weight: 100
-           podAffinityTerm:
-             topologyKey: "kubernetes.io/hostname"
-             labelSelector:
-               matchLabels:
-                 k8s-app: aws-cloud-controller-manager
+         requiredDuringSchedulingIgnoredDuringExecution:
+         - topologyKey: "kubernetes.io/hostname"
+           labelSelector:
+             matchLabels:
+               k8s-app: aws-cloud-controller-manager
      # All CCMs are currently using cloud-controller-manager ServiceAccount
      # with permissions copying in-tree counterparts.
      serviceAccountName: cloud-controller-manager

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -51,13 +51,11 @@ spec:
         node-role.kubernetes.io/master: ""
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  k8s-app: aws-cloud-controller-manager
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                k8s-app: aws-cloud-controller-manager
       serviceAccountName: cloud-controller-manager
       tolerations:
       - effect: NoSchedule

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -24,13 +24,11 @@ spec:
         node-role.kubernetes.io/master: ""
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 1
-            podAffinityTerm:
-              topologyKey: "kubernetes.io/hostname"
-              labelSelector:
-                matchLabels:
-                  app: openstack-cloud-controller-manager
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                app: openstack-cloud-controller-manager
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists


### PR DESCRIPTION
If CCMs are deployed on the same node, only one can start successfully. Other are in CrashLoopBackOff with this error message:

```txt
error: failed to create listener: failed to listen on 127.0.0.1:10258: listen tcp 127.0.0.1:10258: bind: address already in use
```
```sh
$ oc get pod -n openshift-cloud-controller-manager -owide
NAME                                                  READY   STATUS             RESTARTS   AGE   IP             NODE                      NOMINATED NODE   READINESS GATES
openstack-cloud-controller-manager-7c7df77595-7w4v9   1/1     Running            10         30m   10.0.129.124   mfedosin-tb5dj-master-1   <none>           <none>
openstack-cloud-controller-manager-7c7df77595-xphlm   0/1     CrashLoopBackOff   6          30m   10.0.129.124   mfedosin-tb5dj-master-1   <none>           <none>
```

To prevent them to be scheduled together this commit sets a stricter podAntiAffinity type: `requiredDuringSchedulingIgnoredDuringExecution`.