### PR TITLE
Use just one CCM replica for Single Node deployments

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,6 +27,7 @@ type OperatorConfig struct {
 	ManagedNamespace string
 	ControllerImage  string
 	CloudNodeImage   string
+	IsSingleReplica  bool
 	Platform         configv1.PlatformType
 }
 
@@ -102,7 +103,7 @@ func getCloudNodeManagerFromImages(platform configv1.PlatformType, images images
 }
 
 // ComposeConfig creates a Config for operator
-func ComposeConfig(platform configv1.PlatformType, imagesFile, managedNamespace string) (OperatorConfig, error) {
+func ComposeConfig(platform configv1.PlatformType, imagesFile, managedNamespace string, isSingleReplica bool) (OperatorConfig, error) {
 	images, err := getImagesFromJSONFile(imagesFile)
 	if err != nil {
 		klog.Errorf("Unable to decode images file from location %s", imagesFile, err)
@@ -114,6 +115,7 @@ func ComposeConfig(platform configv1.PlatformType, imagesFile, managedNamespace 
 		ManagedNamespace: managedNamespace,
 		ControllerImage:  getCloudControllerManagerFromImages(platform, images),
 		CloudNodeImage:   getCloudNodeManagerFromImages(platform, images),
+		IsSingleReplica:  isSingleReplica,
 	}
 
 	return config, nil

--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -130,7 +130,9 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	config, err := config.ComposeConfig(platform, r.ImagesFile, r.ManagedNamespace)
+	isSingleReplica := infra.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode
+
+	config, err := config.ComposeConfig(platform, r.ImagesFile, r.ManagedNamespace, isSingleReplica)
 	if err != nil {
 		klog.Errorf("Unable to build operator config %s", err)
 		if err := r.setStatusDegraded(ctx, err); err != nil {

--- a/pkg/substitution/substitution.go
+++ b/pkg/substitution/substitution.go
@@ -5,6 +5,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -49,6 +50,9 @@ func FillConfigValues(config config.OperatorConfig, templates []client.Object) [
 		switch obj := templateCopy.(type) {
 		case *appsv1.Deployment:
 			obj.Spec.Template.Spec = setCloudControllerImage(config, obj.Spec.Template.Spec)
+			if config.IsSingleReplica {
+				obj.Spec.Replicas = pointer.Int32(1)
+			}
 		case *appsv1.DaemonSet:
 			obj.Spec.Template.Spec = setCloudControllerImage(config, obj.Spec.Template.Spec)
 		case *corev1.Pod:


### PR DESCRIPTION
In case of Single Node deployments we need to create just one CCM replica, because there will be a port conflict if there are many
of them.

To do so we observe the Infrastructure resource to check what kind of control plane topology the cluster has. If it's `SingleReplicaTopologyMode` then the operator creates just one CCM replica.