### PR TITLE
Update the container init script to not use the legacy workaround

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -151,8 +151,6 @@ spec:
           set -o allexport
           if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
             source /etc/kubernetes/apiserver-url.env
-          else
-            URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
           fi
           exec /cluster-controller-manager-operator \
           --leader-elect \
@@ -180,8 +178,6 @@ spec:
             set -o allexport
             if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
               source /etc/kubernetes/apiserver-url.env
-            else
-              URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
             fi
             exec /cloud-config-sync-controller \
             --leader-elect \

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -27,8 +27,6 @@ spec:
           set -o allexport
           if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
             source /etc/kubernetes/apiserver-url.env
-          else
-            URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
           fi
           exec /bin/aws-cloud-controller-manager \
           --cloud-provider=aws \

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -174,12 +174,14 @@ func checkVolumes(t *testing.T, podSpec corev1.PodSpec) {
 func checkContainerCommand(t *testing.T, podSpec corev1.PodSpec) {
 	binBash := "/bin/bash"
 	dashC := "-c"
+	// This script should be present on every node.
+	// https://github.com/openshift/machine-config-operator/pull/2232
+	// The script sets the API server URL environment variables that
+	// the client SDK detects automatically.
 	setAPIEnv := `#!/bin/bash
 set -o allexport
 if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
   source /etc/kubernetes/apiserver-url.env
-else
-  URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
 fi
 exec `
 

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -56,8 +56,6 @@ spec:
             set -o allexport
             if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
               source /etc/kubernetes/apiserver-url.env
-            else
-              URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
             fi
             exec /usr/bin/openstack-cloud-controller-manager \
             --v=1 \


### PR DESCRIPTION
This updates the init script that must be present on pods/containers to remove the legacy fallback. I've also added a note to the test that links to where the current solution was implemented in MCO. ie https://github.com/openshift/machine-config-operator/pull/2232