### PR TITLE
[OCPCLOUD-1202] Allow CCMs to observe cluster wide proxy

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
@@ -39,6 +39,15 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - proxies
+  verbs:
+  - list
+  - get
+  - watch
+
+- apiGroups:
+  - config.openshift.io
+  resources:
   - infrastructures
   - featuregates
   verbs:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,6 +26,7 @@ type OperatorConfig struct {
 	IsSingleReplica    bool
 	InfrastructureName string
 	Platform           configv1.PlatformType
+	ClusterProxy       *configv1.Proxy
 }
 
 // GetProviderFromInfrastructure reads the Infrastructure resource and returns Platform value
@@ -79,7 +80,7 @@ func getCloudNodeManagerFromImages(platform configv1.PlatformType, images images
 }
 
 // ComposeConfig creates a Config for operator
-func ComposeConfig(infrastructure *configv1.Infrastructure, imagesFile, managedNamespace string) (OperatorConfig, error) {
+func ComposeConfig(infrastructure *configv1.Infrastructure, clusterProxy *configv1.Proxy, imagesFile, managedNamespace string) (OperatorConfig, error) {
 	platform, err := GetProviderFromInfrastructure(infrastructure)
 	if err != nil {
 		klog.Errorf("Unable to get platform from infrastructure: %s", err)
@@ -94,6 +95,7 @@ func ComposeConfig(infrastructure *configv1.Infrastructure, imagesFile, managedN
 
 	config := OperatorConfig{
 		Platform:           platform,
+		ClusterProxy:       clusterProxy,
 		ManagedNamespace:   managedNamespace,
 		ControllerImage:    getCloudControllerManagerFromImages(platform, images),
 		CloudNodeImage:     getCloudNodeManagerFromImages(platform, images),


### PR DESCRIPTION
To conform with existing components within OpenShift, this commit allows the operator to watch for ClusterWideProxy configuration and inject the relevant environment variables into the containers for the CCMs.

This ensures that cloud provider traffic is routed via customers proxies as per the rest of the outbound traffic from the OpenShift components.