### PR TITLE
Fix fmt test in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ run: verify manifests
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
-# Run go fmt against code
+# Check formatting of the code
 .PHONY: fmt
 fmt:
-	go fmt ./...
+	./hack/verify-gofmt.sh
 
 # Run go vet against code
 .PHONY: vet
@@ -73,6 +73,11 @@ image:
 .PHONY: push
 push:
 	docker push ${IMG}
+
+# Run go fmt against code
+.PHONY: update-fmt
+update-fmt:
+	go fmt ./...
 
 # Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,20 @@
+
+#!/bin/bash
+
+function list_go_src_files() {
+	find . -not \( \
+		\( \
+		-wholename './.*' \
+		-o -wholename '*/vendor/*' \
+		\) -prune \
+	\) -name '*.go' | sort -u
+}
+
+
+bad_files=$(list_go_src_files | xargs gofmt -s -l)
+if [[ -n "${bad_files}" ]]; then
+        echo "Here is a list of badly formatted files:"
+        echo "${bad_files}"
+        echo "Try running 'make update-fmt' to fix them."
+        exit 1
+fi


### PR DESCRIPTION
Currently we expect that "make fmt" just checks the code and returns an error when it's badly formatted. Unfortunately, it just fixes the code and always finishes successfully.

To fix if, this commit introduces a new script "verify-gofmt.sh" that is used in the original "fmt" target. The "fmt" itself is renamed
to "update-fmt" to comply with what it actually does.