### PR TITLE
Azure Stack separate assets

### DIFF
--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -27,7 +27,7 @@ func init() {
 	utilruntime.Must(err)
 }
 
-// GetResources returns a list of AWS resources for provisioning CCM in running cluster
+// GetResources returns a list of Azure resources for provisioning CCM in running cluster
 func GetResources() []client.Object {
 	resources := make([]client.Object, len(azureResources))
 	for i := range azureResources {

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -1,0 +1,101 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: azure-cloud-controller-manager
+  namespace: openshift-cloud-controller-manager
+  labels:
+    app: azure-cloud-controller-manager
+spec:
+  selector:
+    matchLabels:
+      app: azure-cloud-controller-manager
+  template:
+    metadata:
+      labels:
+        app: azure-cloud-controller-manager
+    spec:
+      hostNetwork: true
+      serviceAccountName: cloud-controller-manager
+      priorityClassName: system-cluster-critical
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
+              labelSelector:
+                matchLabels:
+                  app: azure-cloud-controller-manager
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+      containers:
+        - name: cloud-controller-manager
+          image: quay.io/openshift/origin-azure-cloud-controller-manager:4.8.0
+          imagePullPolicy: "IfNotPresent"
+          env:
+            - name: CLOUD_CONFIG
+              value: /etc/kubernetes-cloud-config/cloud.conf
+            - name: OCP_INFRASTRUCTURE_NAME
+              value: kubernetes # default cluster name in ccm
+            - name: AZURE_ENVIRONMENT_FILEPATH
+              value: /etc/kubernetes-cloud-config/endpoints.conf
+          resources:
+            requests:
+              cpu: 200m
+              memory: 50Mi
+          command:
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              set -o allexport
+              if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
+                source /etc/kubernetes/apiserver-url.env
+              fi
+              exec /bin/azure-cloud-controller-manager \
+                --v=6 \
+                --cloud-config=$(CLOUD_CONFIG) \
+                --cloud-provider=azure \
+                --controllers=*,-cloud-node,-route \
+                --allocate-node-cidrs=false \
+                --configure-cloud-routes=false \
+                --use-service-account-credentials=true \
+                --bind-address=127.0.0.1 \
+                --cluster-name=$(OCP_INFRASTRUCTURE_NAME) \
+                --leader-elect-resource-namespace=openshift-cloud-controller-manager
+          volumeMounts:
+            - name: host-etc-kube
+              mountPath: /etc/kubernetes
+              readOnly: true
+            - name: config-accm
+              mountPath: /etc/kubernetes-cloud-config
+              readOnly: true
+      volumes:
+        - name: config-accm
+          configMap:
+            name: cloud-conf
+            items:
+              - key: cloud.conf
+                path: cloud.conf
+              - key: endpoints
+                path: endpoints.conf
+        - name: host-etc-kube
+          hostPath:
+            path: /etc/kubernetes
+            type: Directory

--- a/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: azure-cloud-node-manager
+  namespace: openshift-cloud-controller-manager
+  labels:
+    component: azure-cloud-node-manager
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      app: azure-cloud-node-manager
+  template:
+    metadata:
+      labels:
+        app: azure-cloud-node-manager
+      annotations:
+        cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
+    spec:
+      priorityClassName: system-node-critical
+      serviceAccountName: cloud-node-manager
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 120
+        - effect: NoSchedule
+          key: node.cloudprovider.kubernetes.io/uninitialized
+          operator: Exists
+        - effect: NoSchedule
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+      containers:
+        - name: cloud-node-manager
+          image: quay.io/openshift/origin-azure-cloud-node-manager:4.8.0
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              set -o allexport
+              if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
+                source /etc/kubernetes/apiserver-url.env
+              fi
+              exec /bin/azure-cloud-node-manager \
+                --node-name=$(NODE_NAME) \
+                --wait-routes=false \
+                --use-instance-metadata=false \
+                --cloud-config=$(CLOUD_CONFIG) \
+                --v=6
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: AZURE_ENVIRONMENT_FILEPATH
+              value: /etc/kubernetes-cloud-config/endpoints.conf
+            - name: CLOUD_CONFIG
+              value: /etc/kubernetes-cloud-config/cloud.conf
+          volumeMounts:
+            - name: host-etc-kube
+              mountPath: /etc/kubernetes
+              readOnly: true
+            - name: config-accm
+              mountPath: /etc/kubernetes-cloud-config
+              readOnly: true
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+      volumes:
+        - name: host-etc-kube
+          hostPath:
+            path: /etc/kubernetes
+            type: Directory
+        - name: config-accm
+          configMap:
+            name: cloud-conf
+            items:
+              - key: cloud.conf
+                path: cloud.conf
+              - key: endpoints
+                path: endpoints.conf

--- a/pkg/cloud/azurestack/azurestack.go
+++ b/pkg/cloud/azurestack/azurestack.go
@@ -27,7 +27,7 @@ func init() {
 	utilruntime.Must(err)
 }
 
-// GetResources returns a list of AWS resources for provisioning CCM in running cluster
+// GetResources returns a list of Azrue Stack Hub resources for provisioning CCM in running cluster
 func GetResources() []client.Object {
 	resources := make([]client.Object, len(azureResources))
 	for i := range azureResources {

--- a/pkg/cloud/azurestack/azurestack.go
+++ b/pkg/cloud/azurestack/azurestack.go
@@ -1,0 +1,38 @@
+package azurestack
+
+import (
+	"embed"
+
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/common"
+	appsv1 "k8s.io/api/apps/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	//go:embed assets/*
+	azureFs embed.FS
+
+	azureResources []client.Object
+
+	azureSources = []common.ObjectSource{
+		{Object: &appsv1.DaemonSet{}, Path: "assets/cloud-node-manager-daemonset.yaml"},
+		{Object: &appsv1.Deployment{}, Path: "assets/cloud-controller-manager-deployment.yaml"},
+	}
+)
+
+func init() {
+	var err error
+	azureResources, err = common.ReadResources(azureFs, azureSources)
+	utilruntime.Must(err)
+}
+
+// GetResources returns a list of AWS resources for provisioning CCM in running cluster
+func GetResources() []client.Object {
+	resources := make([]client.Object, len(azureResources))
+	for i := range azureResources {
+		resources[i] = azureResources[i].DeepCopyObject().(client.Object)
+	}
+
+	return resources
+}

--- a/pkg/cloud/azurestack/azurestack_test.go
+++ b/pkg/cloud/azurestack/azurestack_test.go
@@ -1,0 +1,24 @@
+package azurestack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetResources(t *testing.T) {
+	resources := GetResources()
+	assert.Len(t, resources, 2)
+
+	var names, kinds []string
+	for _, r := range resources {
+		names = append(names, r.GetName())
+		kinds = append(kinds, r.GetObjectKind().GroupVersionKind().Kind)
+	}
+
+	assert.Contains(t, names, "azure-cloud-controller-manager")
+	assert.Contains(t, kinds, "Deployment")
+
+	assert.Contains(t, names, "azure-cloud-node-manager")
+	assert.Contains(t, kinds, "DaemonSet")
+}

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -17,8 +17,8 @@ import (
 // changes in their spec. However you can extend any resource spec with
 // values not specified in the provided source resource. These changes
 // would be preserved.
-func GetResources(platform configv1.PlatformType, platformStatus *configv1.PlatformStatus) []client.Object {
-	switch platform {
+func GetResources(platformStatus *configv1.PlatformStatus) []client.Object {
+	switch platformStatus.Type {
 	case configv1.AWSPlatformType:
 		return aws.GetResources()
 	case configv1.OpenStackPlatformType:
@@ -29,7 +29,7 @@ func GetResources(platform configv1.PlatformType, platformStatus *configv1.Platf
 		}
 		return azure.GetResources()
 	default:
-		klog.Warningf("Unrecognized platform type %q found in infrastructure", platform)
+		klog.Warningf("Unrecognized platform type %q found in infrastructure", platformStatus.Type)
 		return nil
 	}
 }

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -4,6 +4,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/aws"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/azure"
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/azurestack"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/openstack"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -16,16 +17,23 @@ import (
 // changes in their spec. However you can extend any resource spec with
 // values not specified in the provided source resource. These changes
 // would be preserved.
-func GetResources(platform configv1.PlatformType) []client.Object {
+func GetResources(platform configv1.PlatformType, platformStatus *configv1.PlatformStatus) []client.Object {
 	switch platform {
 	case configv1.AWSPlatformType:
 		return aws.GetResources()
 	case configv1.OpenStackPlatformType:
 		return openstack.GetResources()
 	case configv1.AzurePlatformType:
+		if isAzureStackHub(platformStatus) {
+			return azurestack.GetResources()
+		}
 		return azure.GetResources()
 	default:
 		klog.Warningf("Unrecognized platform type %q found in infrastructure", platform)
 		return nil
 	}
+}
+
+func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
+	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
 }

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -86,7 +86,7 @@ func TestGetResources(t *testing.T) {
 
 	for _, tc := range tc {
 		t.Run(tc.name, func(t *testing.T) {
-			resources := GetResources(tc.platform, getDummyPlatformStatus(tc.platform, tc.isAzureStack))
+			resources := GetResources(getDummyPlatformStatus(tc.platform, tc.isAzureStack))
 
 			assert.Equal(t, len(tc.expected), len(resources))
 			assert.EqualValues(t, tc.expected, resources)
@@ -94,7 +94,7 @@ func TestGetResources(t *testing.T) {
 			// Edit and repeat procedure to ensure modification in place is not present
 			if len(resources) > 0 {
 				resources[0].SetName("different")
-				newResources := GetResources(tc.platform, getDummyPlatformStatus(tc.platform, tc.isAzureStack))
+				newResources := GetResources(getDummyPlatformStatus(tc.platform, tc.isAzureStack))
 
 				assert.Equal(t, len(tc.expected), len(newResources))
 				assert.EqualValues(t, tc.expected, newResources)
@@ -130,7 +130,7 @@ func TestResourcesRunBeforeCNI(t *testing.T) {
 	}
 	for _, platform := range platforms {
 		t.Run(string(platform.platfromType), func(t *testing.T) {
-			resources := GetResources(platform.platfromType, platform.platformStatus)
+			resources := GetResources(platform.platformStatus)
 
 			for _, resource := range resources {
 				switch obj := resource.(type) {
@@ -242,7 +242,7 @@ func TestDeploymentPodAntiAffinity(t *testing.T) {
 	}
 	for _, platform := range platforms {
 		t.Run(string(platform.platfromType), func(t *testing.T) {
-			resources := GetResources(platform.platfromType, platform.platformStatus)
+			resources := GetResources(platform.platformStatus)
 
 			for _, resource := range resources {
 				switch obj := resource.(type) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,7 +25,7 @@ type OperatorConfig struct {
 	CloudNodeImage     string
 	IsSingleReplica    bool
 	InfrastructureName string
-	Platform           configv1.PlatformType
+	PlatformStatus     *configv1.PlatformStatus
 	ClusterProxy       *configv1.Proxy
 }
 
@@ -94,7 +94,7 @@ func ComposeConfig(infrastructure *configv1.Infrastructure, clusterProxy *config
 	}
 
 	config := OperatorConfig{
-		Platform:           platform,
+		PlatformStatus:     infrastructure.Status.PlatformStatus.DeepCopy(),
 		ClusterProxy:       clusterProxy,
 		ManagedNamespace:   managedNamespace,
 		ControllerImage:    getCloudControllerManagerFromImages(platform, images),

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -242,7 +242,7 @@ func TestComposeConfig(t *testing.T) {
 		expectConfig: OperatorConfig{
 			ControllerImage:  "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
 			ManagedNamespace: defaultManagementNamespace,
-			Platform:         configv1.AWSPlatformType,
+			PlatformStatus:   &configv1.PlatformStatus{Type: configv1.AWSPlatformType},
 		},
 	}, {
 		name:      "Unmarshal images from file for OpenStack",
@@ -261,7 +261,7 @@ func TestComposeConfig(t *testing.T) {
 		expectConfig: OperatorConfig{
 			ControllerImage:  "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager",
 			ManagedNamespace: defaultManagementNamespace,
-			Platform:         configv1.OpenStackPlatformType,
+			PlatformStatus:   &configv1.PlatformStatus{Type: configv1.OpenStackPlatformType},
 		},
 	}, {
 		name:      "Unmarshal images from file for unknown platform returns nothing",
@@ -280,7 +280,7 @@ func TestComposeConfig(t *testing.T) {
 		expectConfig: OperatorConfig{
 			ControllerImage:  "",
 			ManagedNamespace: "otherNamespace",
-			Platform:         configv1.NonePlatformType,
+			PlatformStatus:   &configv1.PlatformStatus{Type: configv1.NonePlatformType},
 		},
 	}, {
 		name: "Broken JSON is rejected",
@@ -314,7 +314,7 @@ func TestComposeConfig(t *testing.T) {
 		expectConfig: OperatorConfig{
 			ControllerImage:  "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager",
 			ManagedNamespace: defaultManagementNamespace,
-			Platform:         configv1.OpenStackPlatformType,
+			PlatformStatus:   &configv1.PlatformStatus{Type: configv1.OpenStackPlatformType},
 			IsSingleReplica:  true,
 		},
 	}, {
@@ -354,13 +354,38 @@ func TestComposeConfig(t *testing.T) {
 		expectConfig: OperatorConfig{
 			ControllerImage:  "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
 			ManagedNamespace: defaultManagementNamespace,
-			Platform:         configv1.AWSPlatformType,
+			PlatformStatus:   &configv1.PlatformStatus{Type: configv1.AWSPlatformType},
 			ClusterProxy: &configv1.Proxy{
 				Status: configv1.ProxyStatus{
 					HTTPProxy: "http://squid.corp.acme.com:3128",
 				},
 			},
 		},
+	}, {
+		name:        "Empty infra",
+		namespace:   defaultManagementNamespace,
+		infra:       nil,
+		expectError: "platform status is not populated on infrastructure",
+	}, {
+		name:      "Empty Infra Status",
+		namespace: defaultManagementNamespace,
+		infra: &configv1.Infrastructure{
+			Status: configv1.InfrastructureStatus{
+				PlatformStatus: nil,
+			},
+		},
+		expectError: "platform status is not populated on infrastructure",
+	}, {
+		name:      "Empty Platform Type",
+		namespace: defaultManagementNamespace,
+		infra: &configv1.Infrastructure{
+			Status: configv1.InfrastructureStatus{
+				PlatformStatus: &configv1.PlatformStatus{
+					Type: "",
+				},
+			},
+		},
+		expectError: "no platform provider found on infrastructure",
 	}}
 
 	for _, tc := range tc {

--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -140,7 +140,7 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	if err := r.sync(ctx, config); err != nil {
+	if err := r.sync(ctx, config, infra.Status.PlatformStatus); err != nil {
 		klog.Errorf("Unable to sync operands: %s", err)
 		if err := r.setStatusDegraded(ctx, err); err != nil {
 			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
@@ -157,9 +157,9 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 	return ctrl.Result{}, nil
 }
 
-func (r *CloudOperatorReconciler) sync(ctx context.Context, config config.OperatorConfig) error {
+func (r *CloudOperatorReconciler) sync(ctx context.Context, config config.OperatorConfig, platformStatus *configv1.PlatformStatus) error {
 	// Deploy resources for platform
-	templates := cloud.GetResources(config.Platform)
+	templates := cloud.GetResources(config.Platform, platformStatus)
 	resources := substitution.FillConfigValues(config, templates)
 
 	updated, err := r.applyResources(ctx, resources)

--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -140,7 +140,7 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	if err := r.sync(ctx, config, infra.Status.PlatformStatus); err != nil {
+	if err := r.sync(ctx, config); err != nil {
 		klog.Errorf("Unable to sync operands: %s", err)
 		if err := r.setStatusDegraded(ctx, err); err != nil {
 			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
@@ -157,9 +157,9 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 	return ctrl.Result{}, nil
 }
 
-func (r *CloudOperatorReconciler) sync(ctx context.Context, config config.OperatorConfig, platformStatus *configv1.PlatformStatus) error {
+func (r *CloudOperatorReconciler) sync(ctx context.Context, config config.OperatorConfig) error {
 	// Deploy resources for platform
-	templates := cloud.GetResources(config.Platform, platformStatus)
+	templates := cloud.GetResources(config.PlatformStatus)
 	resources := substitution.FillConfigValues(config, templates)
 
 	updated, err := r.applyResources(ctx, resources)

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Component sync controller", func() {
 				ManagedNamespace: testManagedNamespace,
 				ControllerImage:  "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
 			},
-			expected: cloud.GetResources(configv1.AWSPlatformType),
+			expected: cloud.GetResources(configv1.AWSPlatformType, &configv1.PlatformStatus{}),
 		}),
 		Entry("Should provision OpenStack resources", testCase{
 			status: &configv1.InfrastructureStatus{
@@ -339,7 +339,7 @@ var _ = Describe("Component sync controller", func() {
 				ControllerImage:  "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager",
 			},
 			featureGateSpec: externalFeatureGateSpec,
-			expected:        cloud.GetResources(configv1.OpenStackPlatformType),
+			expected:        cloud.GetResources(configv1.OpenStackPlatformType, &configv1.PlatformStatus{}),
 		}),
 		Entry("Should not provision resources for currently unsupported platform", testCase{
 			status: &configv1.InfrastructureStatus{
@@ -405,7 +405,7 @@ var _ = Describe("Apply resources should", func() {
 	})
 
 	It("Expect update when resources are not found", func() {
-		resources = append(resources, cloud.GetResources(configv1.AWSPlatformType)...)
+		resources = append(resources, cloud.GetResources(configv1.AWSPlatformType, &configv1.PlatformStatus{})...)
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -415,7 +415,7 @@ var _ = Describe("Apply resources should", func() {
 
 	It("Expect update when deployment generation have changed", func() {
 		var dep *appsv1.Deployment
-		for _, res := range cloud.GetResources(configv1.AWSPlatformType) {
+		for _, res := range cloud.GetResources(configv1.AWSPlatformType, &configv1.PlatformStatus{}) {
 			if deployment, ok := res.(*appsv1.Deployment); ok {
 				dep = deployment
 				break
@@ -442,7 +442,7 @@ var _ = Describe("Apply resources should", func() {
 	})
 
 	It("Expect error when object requested is incorrect", func() {
-		objects := cloud.GetResources(configv1.AWSPlatformType)
+		objects := cloud.GetResources(configv1.AWSPlatformType, &configv1.PlatformStatus{})
 		objects[0].SetNamespace("non-existent")
 
 		updated, err := reconciler.applyResources(context.TODO(), objects)
@@ -452,7 +452,7 @@ var _ = Describe("Apply resources should", func() {
 	})
 
 	It("Expect no update when resources are applied twice", func() {
-		resources = append(resources, cloud.GetResources(configv1.OpenStackPlatformType)...)
+		resources = append(resources, cloud.GetResources(configv1.OpenStackPlatformType, &configv1.PlatformStatus{})...)
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Component sync controller", func() {
 				ManagedNamespace: testManagedNamespace,
 				ControllerImage:  "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
 			},
-			expected: cloud.GetResources(configv1.AWSPlatformType, &configv1.PlatformStatus{}),
+			expected: cloud.GetResources(&configv1.PlatformStatus{Type: configv1.AWSPlatformType}),
 		}),
 		Entry("Should provision OpenStack resources", testCase{
 			status: &configv1.InfrastructureStatus{
@@ -339,7 +339,7 @@ var _ = Describe("Component sync controller", func() {
 				ControllerImage:  "registry.ci.openshift.org/openshift:openstack-cloud-controller-manager",
 			},
 			featureGateSpec: externalFeatureGateSpec,
-			expected:        cloud.GetResources(configv1.OpenStackPlatformType, &configv1.PlatformStatus{}),
+			expected:        cloud.GetResources(&configv1.PlatformStatus{Type: configv1.OpenStackPlatformType}),
 		}),
 		Entry("Should not provision resources for currently unsupported platform", testCase{
 			status: &configv1.InfrastructureStatus{
@@ -405,7 +405,7 @@ var _ = Describe("Apply resources should", func() {
 	})
 
 	It("Expect update when resources are not found", func() {
-		resources = append(resources, cloud.GetResources(configv1.AWSPlatformType, &configv1.PlatformStatus{})...)
+		resources = append(resources, cloud.GetResources(&configv1.PlatformStatus{Type: configv1.AWSPlatformType})...)
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -415,7 +415,7 @@ var _ = Describe("Apply resources should", func() {
 
 	It("Expect update when deployment generation have changed", func() {
 		var dep *appsv1.Deployment
-		for _, res := range cloud.GetResources(configv1.AWSPlatformType, &configv1.PlatformStatus{}) {
+		for _, res := range cloud.GetResources(&configv1.PlatformStatus{Type: configv1.AWSPlatformType}) {
 			if deployment, ok := res.(*appsv1.Deployment); ok {
 				dep = deployment
 				break
@@ -442,7 +442,7 @@ var _ = Describe("Apply resources should", func() {
 	})
 
 	It("Expect error when object requested is incorrect", func() {
-		objects := cloud.GetResources(configv1.AWSPlatformType, &configv1.PlatformStatus{})
+		objects := cloud.GetResources(&configv1.PlatformStatus{Type: configv1.AWSPlatformType})
 		objects[0].SetNamespace("non-existent")
 
 		updated, err := reconciler.applyResources(context.TODO(), objects)
@@ -452,7 +452,7 @@ var _ = Describe("Apply resources should", func() {
 	})
 
 	It("Expect no update when resources are applied twice", func() {
-		resources = append(resources, cloud.GetResources(configv1.OpenStackPlatformType, &configv1.PlatformStatus{})...)
+		resources = append(resources, cloud.GetResources(&configv1.PlatformStatus{Type: configv1.OpenStackPlatformType})...)
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
There is plenty of changes between public Azure and Stack one. With current substitution approach it is not convenient to handle it. Extracted to separate module.