### PR TITLE
Allow CCMs to get services and configmaps

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_03_rbac_provider.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_03_rbac_provider.yaml
@@ -89,6 +89,7 @@ rules:
   resources:
   - services
   verbs:
+  - get
   - list
   - patch
   - update
@@ -142,6 +143,12 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
 - apiGroups:
   - "coordination.k8s.io"
   resources:


### PR DESCRIPTION
IBM CCM has a load balancer service monitor that needs to get services in order
to properly monitor their overall health. It also needs to access cluster
configuration data via configmaps in the kube-system namespace. RBAC updates
for the former will likely always be required for the IBM CCM. The later could
be removed if the IBM CCM configuration was refactored.

Related: https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/97