### PR TITLE
Bug 1985366: Use registered ports and ensure that ports are defined in pod specs

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -67,8 +67,15 @@ spec:
             fi
             exec /cloud-config-sync-controller \
             --leader-elect \
-            --metrics-bind-address=:8081 \
-            --health-addr=:9441
+            --metrics-bind-address=:9258 \
+            --health-addr=127.0.0.1:9259
+        ports:
+        - containerPort: 9258
+          name: metrics
+          protocol: TCP
+        - containerPort: 9259
+          name: healthz
+          protocol: TCP
         resources:
           requests:
             cpu: 10m

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -36,6 +36,10 @@ spec:
         image: quay.io/openshift/origin-aws-cloud-controller-manager
         imagePullPolicy: IfNotPresent
         name: cloud-controller-manager
+        ports:
+        - containerPort: 10258
+          name: https
+          protocol: TCP
         resources:
           requests:
             cpu: 200m

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -57,6 +57,10 @@ spec:
             requests:
               cpu: 200m
               memory: 50Mi
+          ports:
+          - containerPort: 10258
+            name: https
+            protocol: TCP
           command:
             - /bin/bash
             - -c

--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -56,6 +56,10 @@ spec:
               exec /bin/azure-cloud-node-manager \
                 --node-name=$(NODE_NAME) \
                 --wait-routes=false
+          ports:
+          - containerPort: 10263
+            name: https
+            protocol: TCP
           env:
             - name: NODE_NAME
               valueFrom:

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -59,6 +59,10 @@ spec:
             requests:
               cpu: 200m
               memory: 50Mi
+          ports:
+          - containerPort: 10258
+            name: https
+            protocol: TCP
           command:
             - /bin/bash
             - -c

--- a/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
@@ -59,6 +59,10 @@ spec:
                 --use-instance-metadata=false \
                 --cloud-config=$(CLOUD_CONFIG) \
                 --v=6
+          ports:
+          - containerPort: 10263
+            name: https
+            protocol: TCP
           env:
             - name: NODE_NAME
               valueFrom:

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -134,7 +134,14 @@ func TestResourcesRunBeforeCNI(t *testing.T) {
 		{configv1.NonePlatformType, getDummyPlatformStatus(configv1.NonePlatformType, false)},
 	}
 	for _, platform := range platforms {
-		t.Run(string(platform.platfromType), func(t *testing.T) {
+		platformName := string(platform.platfromType)
+		if platform.platformStatus != nil &&
+			platform.platformStatus.Azure != nil &&
+			platform.platformStatus.Azure.CloudName == configv1.AzureStackCloud {
+			platformName += "StackHub"
+		}
+
+		t.Run(platformName, func(t *testing.T) {
 			resources := GetResources(platform.platformStatus)
 
 			for _, resource := range resources {
@@ -267,7 +274,14 @@ func TestDeploymentPodAntiAffinity(t *testing.T) {
 		{configv1.NonePlatformType, getDummyPlatformStatus(configv1.NonePlatformType, false)},
 	}
 	for _, platform := range platforms {
-		t.Run(string(platform.platfromType), func(t *testing.T) {
+		platformName := string(platform.platfromType)
+		if platform.platformStatus != nil &&
+			platform.platformStatus.Azure != nil &&
+			platform.platformStatus.Azure.CloudName == configv1.AzureStackCloud {
+			platformName += "StackHub"
+		}
+
+		t.Run(platformName, func(t *testing.T) {
 			resources := GetResources(platform.platformStatus)
 
 			for _, resource := range resources {

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -64,6 +64,10 @@ spec:
             --use-service-account-credentials=true \
             --bind-address=127.0.0.1 \
             --leader-elect-resource-namespace=openshift-cloud-controller-manager
+          ports:
+          - containerPort: 10258
+            name: https
+            protocol: TCP
           resources:
             requests:
               cpu: 200m


### PR DESCRIPTION
Per the guidelines in https://github.com/openshift/enhancements/blob/master/dev-guide/host-port-registry.md, we should only be using defined ports when running on host network.

This implements the requirements of that guide based off of the ports registered in https://github.com/openshift/enhancements/pull/847

/hold until the registered ports are agreed upon