### PR TITLE
Bug 1997507: Prevent host port clashing on SNO

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -13,6 +13,8 @@ spec:
     matchLabels:
       k8s-app: cloud-manager-operator
   replicas: 1
+  stategy:
+    type: Recreate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Because we use a host port, when the pod is being updated, it has to schedule onto a node that doesn't already have a running CCCMO. This doesn't work for SNO as there is only one node. To prevent this block, we have to use the recreate deployment strategy