### PR TITLE
Bug 1998466: Ensure CCM pods can be updated on SNO clusters

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       k8s-app: aws-cloud-controller-manager
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       app: azure-cloud-controller-manager
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       app: azure-cloud-controller-manager
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       app: openstack-cloud-controller-manager
+  strategy:
+    type: Recreate
   template:
     metadata:
       annotations:


### PR DESCRIPTION
As CCM pods all request a host port, we must set the update strategy to recreate so that the existing CCM pods are removed (freeing the port), before creating the new pod. This will allow updates to the CCM deployments on SNO.