### PR TITLE
Bug 1999018: Ensure rollingUpdate strategy is cleared to allow upgrades

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -15,6 +15,7 @@ spec:
   replicas: 1
   stategy:
     type: Recreate
+    rollingUpdate: {}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Because we moved the strategy to `Recreate` in #108, the rollingUpdate field must be empty. If it is not empty, this prevents the upgrade from going through. This should force it to empty to allow the upgrade. 