### PR TITLE
Bug 2000191: Ensure CCCMO and CCMs adheres to OpenShift recommended leader election

### DIFF
--- a/cmd/cloud-config-sync-controller/main.go
+++ b/cmd/cloud-config-sync-controller/main.go
@@ -21,22 +21,26 @@ import (
 	"os"
 	"time"
 
+	"github.com/spf13/pflag"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
-
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
-	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/klogr"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/component-base/config"
+	"k8s.io/component-base/config/options"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/controllers"
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/util"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -44,10 +48,13 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 
-	// The default durations for the leader electrion operations.
-	leaseDuration = 120 * time.Second
-	renewDealine  = 110 * time.Second
-	retryPeriod   = 90 * time.Second
+	leaderElectionConfig = config.LeaderElectionConfiguration{
+		LeaderElect:   true,
+		LeaseDuration: util.LeaseDuration,
+		RenewDeadline: util.RenewDeadline,
+		RetryPeriod:   util.RetryPeriod,
+		ResourceName:  "cluster-cloud-config-sync-leader",
+	}
 )
 
 func init() {
@@ -72,31 +79,17 @@ func main() {
 		"The address for health checking.",
 	)
 
-	leaderElectResourceNamespace := flag.String(
-		"leader-elect-resource-namespace",
-		"",
-		"The namespace of resource object that is used for locking during leader election. If unspecified and running in cluster, defaults to the service account namespace for the controller. Required for leader-election outside of a cluster.",
-	)
-
-	leaderElect := flag.Bool(
-		"leader-elect",
-		false,
-		"Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.",
-	)
-
-	leaderElectLeaseDuration := flag.Duration(
-		"leader-elect-lease-duration",
-		leaseDuration,
-		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
-	)
-
 	managedNamespace := flag.String(
 		"namespace",
 		controllers.DefaultManagedNamespace,
 		"The namespace for managed objects, target cloud-conf in particular.",
 	)
 
-	flag.Parse()
+	// Once all the flags are regitered, switch to pflag
+	// to allow leader lection flags to be bound
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	options.BindLeaderElectionFlags(&leaderElectionConfig, pflag.CommandLine)
+	pflag.Parse()
 
 	ctrl.SetLogger(klogr.New().WithName("CCMOCloudConfigSyncController"))
 
@@ -110,12 +103,12 @@ func main() {
 		SyncPeriod:              &syncPeriod,
 		MetricsBindAddress:      *metricsAddr,
 		HealthProbeBindAddress:  *healthAddr,
-		LeaderElectionNamespace: *leaderElectResourceNamespace,
-		LeaderElection:          *leaderElect,
-		LeaseDuration:           leaderElectLeaseDuration,
-		LeaderElectionID:        "cloud-config-sync-controller-leader",
-		RetryPeriod:             &retryPeriod,
-		RenewDeadline:           &renewDealine,
+		LeaderElectionNamespace: leaderElectionConfig.ResourceNamespace,
+		LeaderElection:          leaderElectionConfig.LeaderElect,
+		LeaseDuration:           &leaderElectionConfig.LeaseDuration.Duration,
+		LeaderElectionID:        leaderElectionConfig.ResourceName,
+		RetryPeriod:             &leaderElectionConfig.RetryPeriod.Duration,
+		RenewDeadline:           &leaderElectionConfig.RenewDeadline.Duration,
 		NewCache:                cacheBuilder,
 	})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,14 @@ require (
 	github.com/openshift/api v0.0.0-20210817132244-67c28690af52
 	github.com/openshift/library-go v0.0.0-20210817120645-b59564e63303
 	github.com/spf13/cobra v1.1.3
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.0.0-20210716203947-853a461950ff // indirect
 	k8s.io/api v0.22.0
 	k8s.io/apiextensions-apiserver v0.22.0
 	k8s.io/apimachinery v0.22.0
 	k8s.io/client-go v0.22.0
+	k8s.io/component-base v0.22.0
 	k8s.io/klog/v2 v2.10.0
 	k8s.io/utils v0.0.0-20210802155522-efc7438f0176
 	sigs.k8s.io/controller-runtime v0.9.6

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -40,7 +40,11 @@ spec:
             URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
           fi
           exec /cluster-controller-manager-operator \
-          --leader-elect \
+          --leader-elect=true \
+          --leader-elect-lease-duration=137s \
+          --leader-elect-renew-deadline=107s \
+          --leader-elect-retry-period=26s \
+          --leader-elect-resource-namespace=openshift-cloud-controller-manager-operator \
           "--images-json=/etc/cloud-controller-manager-config/images.json"
         env:
         - name: RELEASE_VERSION
@@ -69,7 +73,11 @@ spec:
               URL_ONLY_KUBECONFIG=/etc/kubernetes/kubeconfig
             fi
             exec /cloud-config-sync-controller \
-            --leader-elect \
+            --leader-elect=true \
+            --leader-elect-lease-duration=137s \
+            --leader-elect-renew-deadline=107s \
+            --leader-elect-retry-period=26s \
+            --leader-elect-resource-namespace=openshift-cloud-controller-manager-operator \
             --metrics-bind-address=:9258 \
             --health-addr=127.0.0.1:9259
         ports:

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -33,6 +33,10 @@ spec:
           exec /bin/aws-cloud-controller-manager \
           --cloud-provider=aws \
           --use-service-account-credentials=true \
+          --leader-elect=true \
+          --leader-elect-lease-duration=137s \
+          --leader-elect-renew-deadline=107s \
+          --leader-elect-retry-period=26s \
           --leader-elect-resource-namespace=openshift-cloud-controller-manager \
           -v=2
         image: quay.io/openshift/origin-aws-cloud-controller-manager

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -82,6 +82,10 @@ spec:
                 --use-service-account-credentials=true \
                 --bind-address=127.0.0.1 \
                 --cluster-name=$(OCP_INFRASTRUCTURE_NAME) \
+                --leader-elect=true \
+                --leader-elect-lease-duration=137s \
+                --leader-elect-renew-deadline=107s \
+                --leader-elect-retry-period=26s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -109,6 +109,10 @@ spec:
                 --use-service-account-credentials=true \
                 --bind-address=127.0.0.1 \
                 --cluster-name=$(OCP_INFRASTRUCTURE_NAME) \
+                --leader-elect=true \
+                --leader-elect-lease-duration=137s \
+                --leader-elect-renew-deadline=107s \
+                --leader-elect-retry-period=26s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -65,6 +65,10 @@ spec:
             --cloud-provider=openstack \
             --use-service-account-credentials=true \
             --bind-address=127.0.0.1 \
+            --leader-elect=true \
+            --leader-elect-lease-duration=137s \
+            --leader-elect-renew-deadline=107s \
+            --leader-elect-retry-period=26s \
             --leader-elect-resource-namespace=openshift-cloud-controller-manager
           ports:
           - containerPort: 10258

--- a/pkg/util/durations.go
+++ b/pkg/util/durations.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2021 Red Hat.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The default durations for the leader election operations.
+var (
+	// LeaseDuration is the default duration for the leader election lease.
+	LeaseDuration = metav1.Duration{Duration: 137 * time.Second}
+	// RenewDeadline is the default duration for the leader renewal.
+	RenewDeadline = metav1.Duration{Duration: 107 * time.Second}
+	// RetryPeriod is the default duration for the leader election retrial.
+	RetryPeriod = metav1.Duration{Duration: 26 * time.Second}
+)

--- a/vendor/k8s.io/component-base/config/options/leaderelectionconfig.go
+++ b/vendor/k8s.io/component-base/config/options/leaderelectionconfig.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+	"k8s.io/component-base/config"
+)
+
+// BindLeaderElectionFlags binds the LeaderElectionConfiguration struct fields to a flagset
+func BindLeaderElectionFlags(l *config.LeaderElectionConfiguration, fs *pflag.FlagSet) {
+	fs.BoolVar(&l.LeaderElect, "leader-elect", l.LeaderElect, ""+
+		"Start a leader election client and gain leadership before "+
+		"executing the main loop. Enable this when running replicated "+
+		"components for high availability.")
+	fs.DurationVar(&l.LeaseDuration.Duration, "leader-elect-lease-duration", l.LeaseDuration.Duration, ""+
+		"The duration that non-leader candidates will wait after observing a leadership "+
+		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+		"slot. This is effectively the maximum duration that a leader can be stopped "+
+		"before it is replaced by another candidate. This is only applicable if leader "+
+		"election is enabled.")
+	fs.DurationVar(&l.RenewDeadline.Duration, "leader-elect-renew-deadline", l.RenewDeadline.Duration, ""+
+		"The interval between attempts by the acting master to renew a leadership slot "+
+		"before it stops leading. This must be less than or equal to the lease duration. "+
+		"This is only applicable if leader election is enabled.")
+	fs.DurationVar(&l.RetryPeriod.Duration, "leader-elect-retry-period", l.RetryPeriod.Duration, ""+
+		"The duration the clients should wait between attempting acquisition and renewal "+
+		"of a leadership. This is only applicable if leader election is enabled.")
+	fs.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
+		"The type of resource object that is used for locking during "+
+		"leader election. Supported options are 'endpoints', 'configmaps', "+
+		"'leases', 'endpointsleases' and 'configmapsleases'.")
+	fs.StringVar(&l.ResourceName, "leader-elect-resource-name", l.ResourceName, ""+
+		"The name of resource object that is used for locking during "+
+		"leader election.")
+	fs.StringVar(&l.ResourceNamespace, "leader-elect-resource-namespace", l.ResourceNamespace, ""+
+		"The namespace of resource object that is used for locking during "+
+		"leader election.")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -143,6 +143,7 @@ github.com/prometheus/procfs/internal/util
 ## explicit
 github.com/spf13/cobra
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.7.0
 ## explicit
@@ -486,7 +487,9 @@ k8s.io/client-go/util/keyutil
 k8s.io/client-go/util/retry
 k8s.io/client-go/util/workqueue
 # k8s.io/component-base v0.22.0
+## explicit
 k8s.io/component-base/config
+k8s.io/component-base/config/options
 k8s.io/component-base/config/v1alpha1
 # k8s.io/klog/v2 v2.10.0
 ## explicit


### PR DESCRIPTION
To ensure consistency with other components within OpenShift, this PR enforces (via unit tests) a consistent set of leader election flags which adhere to the guidelines set out in the conentions (https://github.com/openshift/enhancements/blob/master/CONVENTIONS.md#handling-kube-apiserver-disruption)