### PR TITLE
Bug 2000191: Update the default durations for CCCMO leader election operations

### DIFF
--- a/cmd/cloud-config-sync-controller/main.go
+++ b/cmd/cloud-config-sync-controller/main.go
@@ -37,17 +37,13 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/controllers"
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/util"
 	// +kubebuilder:scaffold:imports
 )
 
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
-
-	// The default durations for the leader electrion operations.
-	leaseDuration = 120 * time.Second
-	renewDealine  = 110 * time.Second
-	retryPeriod   = 90 * time.Second
 )
 
 func init() {
@@ -86,7 +82,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		leaseDuration,
+		util.LeaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 
@@ -114,8 +110,8 @@ func main() {
 		LeaderElection:          *leaderElect,
 		LeaseDuration:           leaderElectLeaseDuration,
 		LeaderElectionID:        "cloud-config-sync-controller-leader",
-		RetryPeriod:             &retryPeriod,
-		RenewDeadline:           &renewDealine,
+		RetryPeriod:             util.TimeDuration(util.RetryPeriod),
+		RenewDeadline:           util.TimeDuration(util.RenewDeadline),
 		NewCache:                cacheBuilder,
 	})
 	if err != nil {

--- a/cmd/cluster-cloud-controller-manager-operator/main.go
+++ b/cmd/cluster-cloud-controller-manager-operator/main.go
@@ -36,17 +36,13 @@ import (
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/controllers"
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/util"
 	// +kubebuilder:scaffold:imports
 )
 
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
-
-	// The default durations for the leader electrion operations.
-	leaseDuration = 120 * time.Second
-	renewDealine  = 110 * time.Second
-	retryPeriod   = 90 * time.Second
 )
 
 const (
@@ -92,7 +88,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		leaseDuration,
+		util.LeaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 
@@ -124,8 +120,8 @@ func main() {
 		LeaderElection:          *leaderElect,
 		LeaseDuration:           leaderElectLeaseDuration,
 		LeaderElectionID:        "cluster-cloud-controller-manager-leader",
-		RetryPeriod:             &retryPeriod,
-		RenewDeadline:           &renewDealine,
+		RetryPeriod:             util.TimeDuration(util.RetryPeriod),
+		RenewDeadline:           util.TimeDuration(util.RenewDeadline),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")

--- a/pkg/util/durations.go
+++ b/pkg/util/durations.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2021 Red Hat.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+)
+
+// The default durations for the leader election operations.
+const (
+	// LeaseDuration is the default duration for the leader election lease.
+	LeaseDuration = 137 * time.Second
+	// RenewDeadline is the default duration for the leader renewal.
+	RenewDeadline = 107 * time.Second
+	// RetryPeriod is the default duration for the leader election retrial.
+	RetryPeriod = 26 * time.Second
+)
+
+// TimeDuration returns a pointer to the time.Duration.
+func TimeDuration(i time.Duration) *time.Duration {
+	return &i
+}


### PR DESCRIPTION
According to [1] to successfully handle kube-apiserver disruption we need to update default durations for CCCMO leader election operations.

New values should be LeaseDuration=137s, RenewDealine=107s, RetryPeriod=26s.

[1] https://github.com/openshift/enhancements/pull/832