### PR TITLE
Bug 1998466: Fix deployment strategy typo

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -13,9 +13,8 @@ spec:
     matchLabels:
       k8s-app: cloud-manager-operator
   replicas: 1
-  stategy:
+  strategy:
     type: Recreate
-    rollingUpdate: {}
   template:
     metadata:
       annotations:


### PR DESCRIPTION
Theres a typo that means the added fields are actually being ignored

Edit: This also removes the `rollingUpdate: {}` as this was actually causing issues of its own. The rollingUpdate field is a pointer so specifying it as empty blocked the update.