### PR TITLE
Bug 2001825: Enforce the cloud-route controller disabled across platforms

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -33,6 +33,7 @@ spec:
           exec /bin/aws-cloud-controller-manager \
           --cloud-provider=aws \
           --use-service-account-credentials=true \
+          --configure-cloud-routes=false \
           --leader-elect=true \
           --leader-elect-lease-duration=137s \
           --leader-elect-renew-deadline=107s \

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -76,8 +76,7 @@ spec:
                 --v=3 \
                 --cloud-config=$(CLOUD_CONFIG) \
                 --cloud-provider=azure \
-                --controllers=*,-cloud-node,-route \
-                --allocate-node-cidrs=false \
+                --controllers=*,-cloud-node \
                 --configure-cloud-routes=false \
                 --use-service-account-credentials=true \
                 --bind-address=127.0.0.1 \

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -103,8 +103,7 @@ spec:
                 --v=6 \
                 --cloud-config=$(CLOUD_CONFIG) \
                 --cloud-provider=azure \
-                --controllers=*,-cloud-node,-route \
-                --allocate-node-cidrs=false \
+                --controllers=*,-cloud-node \
                 --configure-cloud-routes=false \
                 --use-service-account-credentials=true \
                 --bind-address=127.0.0.1 \

--- a/pkg/cloud/ibm/assets/deployment.yaml
+++ b/pkg/cloud/ibm/assets/deployment.yaml
@@ -75,6 +75,7 @@ spec:
             --port=0 \
             --bind-address=$(POD_IP_ADDRESS) \
             --use-service-account-credentials=true \
+            --configure-cloud-routes=false \
             --cloud-provider=ibm \
             --cloud-config=/etc/ibm/cloud.conf \
             --feature-gates=IPv6DualStack=false \
@@ -98,7 +99,7 @@ spec:
             name: https
             protocol: TCP
         resources:
-          # Container is required to set pod requests, but not limits to satisfy CI 
+          # Container is required to set pod requests, but not limits to satisfy CI
           # requirements for OpenShift on every scheduled workload in the cluster
           requests:
             cpu: 75m

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -64,6 +64,7 @@ spec:
             --cloud-config=$(CLOUD_CONFIG) \
             --cloud-provider=openstack \
             --use-service-account-credentials=true \
+            --configure-cloud-routes=false \
             --bind-address=127.0.0.1 \
             --leader-elect=true \
             --leader-elect-lease-duration=137s \


### PR DESCRIPTION
The cloud-route controller is disabled and forced disabled across the board today in OpenShift. This used to be enforced by setting `allocate-node-cidrs=false` but this was removed in https://github.com/kubernetes/cloud-provider/commit/f9aa959a5054f6160c1f5a7577220fbd104cd9bf (Note this is still true with in-tree cloud providers, just out of tree this no longer works).

Now we must set `configure-cloud-routes=false` to ensure that the route controller is not started. This should be a simpler approach to ensure the route controller is forced off than forcing the use of the `--controllers=•,-route` style flags.