### PR TITLE
Check diff after generate and vendor tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
+verify-%:
+	make $*
+	./hack/verify-diff.sh
+
 all: build
 
 verify: fmt vet lint

--- a/hack/verify-diff.sh
+++ b/hack/verify-diff.sh
@@ -1,0 +1,9 @@
+FILE_DIFF=$(git ls-files -o --exclude-standard)
+
+if [ "$FILE_DIFF" != "" ]; then
+  echo "Found untracked files:"
+  echo $FILE_DIFF
+  exit 1
+fi
+
+git diff --exit-code


### PR DESCRIPTION
Now our targets just fix related issues in the code. For CI it means that it doesn't report any errors, as jobs always finish successfully.

This commit adds a script that checks the output of git diff command. If the diff is not empty, then the code has been modified, and therefore it has some errors.

Running this script in CI will force it to report real errors in the jobs logs.

Co-authored-by: Danil Grigorev <dgrigore@redhat.com>