### PR TITLE
Minimize IAM scope for IBM Cloud CredReqs

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_15_credentialsrequest-ibm.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_15_credentialsrequest-ibm.yaml
@@ -15,3 +15,11 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: IBMCloudProviderSpec
+    policies:
+    - roles:
+      - "crn:v1:bluemix:public:iam::::role:Editor"
+      - "crn:v1:bluemix:public:iam::::role:Operator"
+      - "crn:v1:bluemix:public:iam::::role:Viewer"
+      attributes:
+      - name: "serviceName"
+        value: "is"


### PR DESCRIPTION
Minimize the IAM scope for the IBM Cloud CCM, based on required
resources and permissions.