### PR TITLE
Bug 2004924: Enforce the cloud-route controller disabled across platforms

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -33,6 +33,7 @@ spec:
           exec /bin/aws-cloud-controller-manager \
           --cloud-provider=aws \
           --use-service-account-credentials=true \
+          --configure-cloud-routes=false \
           --leader-elect=true \
           --leader-elect-lease-duration=137s \
           --leader-elect-renew-deadline=107s \

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -76,8 +76,7 @@ spec:
                 --v=3 \
                 --cloud-config=$(CLOUD_CONFIG) \
                 --cloud-provider=azure \
-                --controllers=*,-cloud-node,-route \
-                --allocate-node-cidrs=false \
+                --controllers=*,-cloud-node \
                 --configure-cloud-routes=false \
                 --use-service-account-credentials=true \
                 --bind-address=127.0.0.1 \

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -103,8 +103,7 @@ spec:
                 --v=6 \
                 --cloud-config=$(CLOUD_CONFIG) \
                 --cloud-provider=azure \
-                --controllers=*,-cloud-node,-route \
-                --allocate-node-cidrs=false \
+                --controllers=*,-cloud-node \
                 --configure-cloud-routes=false \
                 --use-service-account-credentials=true \
                 --bind-address=127.0.0.1 \

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -156,6 +156,7 @@ func TestPodSpec(t *testing.T) {
 
 				checkResourceRunsBeforeCNI(t, podSpec)
 				checkLeaderElection(t, podSpec)
+				checkCloudControllerManagerFlags(t, podSpec)
 			}
 		})
 	}
@@ -283,9 +284,34 @@ func checkLeaderElection(t *testing.T, podSpec corev1.PodSpec) {
 			continue
 		}
 
+		command := container.Command
+		assert.Len(t, command, 3, "Container Command should have 3 elements")
+
 		for _, flag := range []string{leaderElect, leaderElectLeaseDuration, leaderElectRenewDeadline, leaderElectRetryPeriod, leaderElectResourceNamesapce} {
-			command := container.Command
-			assert.Len(t, command, 3, "Container Command should have 3 elements")
+			assert.Contains(t, command[2], flag, "Container Command third (%q) element should contain flag %q", command[2], flag)
+		}
+	}
+}
+
+func checkCloudControllerManagerFlags(t *testing.T, podSpec corev1.PodSpec) {
+	const (
+		// This flag will disable the cloud route controller.
+		// The route controller is responsible for setting up inter pod networking
+		// using cloud networks, but this isn't required when you have an overlay
+		// network as is used within OpenShift.
+		configureCloudRoutes = "--configure-cloud-routes=false"
+	)
+
+	for _, container := range podSpec.Containers {
+		if container.Name != "cloud-controller-manager" {
+			// Only the cloud-controller-manager container needs these flags checking
+			continue
+		}
+
+		command := container.Command
+		assert.Len(t, command, 3, "Container Command should have 3 elements")
+
+		for _, flag := range []string{configureCloudRoutes} {
 			assert.Contains(t, command[2], flag, "Container Command third (%q) element should contain flag %q", command[2], flag)
 		}
 	}

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -64,6 +64,7 @@ spec:
             --cloud-config=$(CLOUD_CONFIG) \
             --cloud-provider=openstack \
             --use-service-account-credentials=true \
+            --configure-cloud-routes=false \
             --bind-address=127.0.0.1 \
             --leader-elect=true \
             --leader-elect-lease-duration=137s \


### PR DESCRIPTION
Manual cherry-pick of #120 

We must disable the route controller across platforms as it is not supported within OpenShift.