### PR TITLE
Fix "vendor" job

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d
-	github.com/go-logr/logr v1.0.0 // indirect
+	github.com/go-logr/logr v1.0.0
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/onsi/ginkgo v1.16.4


### PR DESCRIPTION
Now the job is broken because "make verify-vendor" returns an error. This commit fixes the problem by updating go.mod file.

The code is automatically generated by `make vendor`.