### PR TITLE
podsecurity: enforce privileged for openshift-cloud-controller-manager-operator namespace

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_00_namespace.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_00_namespace.yaml
@@ -9,6 +9,9 @@ metadata:
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: openshift-cloud-controller-manager-operator
 ---
 apiVersion: v1


### PR DESCRIPTION
Starting with OpenShift 4.10 we are introducing PodSecurity admission (https://github.com/kubernetes/enhancements/tree/master/keps/sig-auth/2579-psp-replacement).

Currently, all pods are marked as privileged, however, over time we want to enforce at least baseline, admirably restricted as default. In order not to break control plane workloads this allows workloads in `openshift-cloud-controller-manager-operator` namespace to run privileged pods.

See https://github.com/openshift/enhancements/pull/899 for more details (and excuse the eventual consistency of updates).

/cc @stlaz 
