### PR TITLE
Get rid of server-side apply

### DIFF
--- a/pkg/controllers/resourceapply/resourceapply.go
+++ b/pkg/controllers/resourceapply/resourceapply.go
@@ -1,0 +1,226 @@
+package resourceapply
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	coreclientv1 "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+)
+
+// Inspired by https://github.com/openshift/library-go/tree/master/pkg/operator/resource/resourceapply
+
+const (
+	specHashAnnotation   = "operator.openshift.io/spec-hash"
+	generationAnnotation = "operator.openshift.io/generation"
+)
+
+// SetSpecHashAnnotation computes the hash of the provided spec and sets an annotation of the
+// hash on the provided ObjectMeta. This method is used internally by Apply<type> methods, and
+// is exposed to support testing with fake clients that need to know the mutated form of the
+// resource resulting from an Apply<type> call.
+func SetSpecHashAnnotation(objMeta *metav1.ObjectMeta, spec interface{}) error {
+	jsonBytes, err := json.Marshal(spec)
+	if err != nil {
+		return err
+	}
+	specHash := fmt.Sprintf("%x", sha256.Sum256(jsonBytes))
+	if objMeta.Annotations == nil {
+		objMeta.Annotations = map[string]string{}
+	}
+	objMeta.Annotations[specHashAnnotation] = specHash
+	return nil
+}
+
+// ApplyResource applies resources of unspecified type
+func ApplyResource(ctx context.Context, client coreclientv1.Client, recorder record.EventRecorder, resource client.Object) (bool, error) {
+	switch t := resource.(type) {
+	case *appsv1.Deployment:
+		return applyDeployment(ctx, client, recorder, t)
+	case *appsv1.DaemonSet:
+		return applyDaemonSet(ctx, client, recorder, t)
+	case *corev1.ConfigMap:
+		return applyConfigMap(ctx, client, recorder, t)
+	default:
+		return false, fmt.Errorf("unhandled type %T", resource)
+	}
+}
+
+func applyConfigMap(ctx context.Context, client coreclientv1.Client, recorder record.EventRecorder, requiredOriginal *corev1.ConfigMap) (bool, error) {
+	required := requiredOriginal.DeepCopy()
+	existing := &corev1.ConfigMap{}
+	err := client.Get(ctx, coreclientv1.ObjectKeyFromObject(requiredOriginal), existing)
+	if apierrors.IsNotFound(err) {
+		err := client.Create(ctx, resourcemerge.WithCleanLabelsAndAnnotations(required).(*corev1.ConfigMap))
+		if err != nil {
+			recorder.Event(required, corev1.EventTypeWarning, "Update failed", err.Error())
+			return false, err
+		}
+		recorder.Event(required, corev1.EventTypeNormal, "Updated successfully", "Resource was successfully updated")
+		return true, nil
+	}
+	if err != nil {
+		recorder.Event(required, corev1.EventTypeWarning, "Update failed", err.Error())
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+
+	var modifiedKeys []string
+	for existingCopyKey, existingCopyValue := range existingCopy.Data {
+		if requiredValue, ok := required.Data[existingCopyKey]; !ok || (existingCopyValue != requiredValue) {
+			modifiedKeys = append(modifiedKeys, "data."+existingCopyKey)
+		}
+	}
+	for existingCopyKey, existingCopyBinValue := range existingCopy.BinaryData {
+		if requiredBinValue, ok := required.BinaryData[existingCopyKey]; !ok || !bytes.Equal(existingCopyBinValue, requiredBinValue) {
+			modifiedKeys = append(modifiedKeys, "binaryData."+existingCopyKey)
+		}
+	}
+	for requiredKey := range required.Data {
+		if _, ok := existingCopy.Data[requiredKey]; !ok {
+			modifiedKeys = append(modifiedKeys, "data."+requiredKey)
+		}
+	}
+	for requiredBinKey := range required.BinaryData {
+		if _, ok := existingCopy.BinaryData[requiredBinKey]; !ok {
+			modifiedKeys = append(modifiedKeys, "binaryData."+requiredBinKey)
+		}
+	}
+
+	dataSame := len(modifiedKeys) == 0
+	if dataSame && !*modified {
+		return false, nil
+	}
+	existingCopy.Data = required.Data
+	existingCopy.BinaryData = required.BinaryData
+
+	// at this point we know that we're going to perform a write.  We're just trying to get the object correct
+	toWrite := existingCopy // shallow copy so the code reads easier
+
+	err = client.Update(ctx, toWrite)
+	if err != nil {
+		recorder.Event(required, corev1.EventTypeWarning, "Update failed", err.Error())
+		return false, err
+	}
+	recorder.Event(toWrite, corev1.EventTypeNormal, "Updated successfully", "Resource was successfully updated")
+	return true, err
+}
+
+func applyDeployment(ctx context.Context, client coreclientv1.Client, recorder record.EventRecorder, requiredOriginal *appsv1.Deployment) (bool, error) {
+	required := requiredOriginal.DeepCopy()
+	err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec)
+	if err != nil {
+		return false, err
+	}
+
+	existing := &appsv1.Deployment{}
+	err = client.Get(ctx, coreclientv1.ObjectKeyFromObject(required), existing)
+	if apierrors.IsNotFound(err) {
+		required.Annotations[generationAnnotation] = "1"
+		err := client.Create(ctx, required)
+		if err != nil {
+			recorder.Event(required, corev1.EventTypeWarning, "Update failed", err.Error())
+			return false, err
+		}
+		recorder.Event(required, corev1.EventTypeNormal, "Updated successfully", "Resource was successfully updated")
+		return true, nil
+	}
+	if err != nil {
+		recorder.Event(required, corev1.EventTypeWarning, "Update failed", err.Error())
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	expectedGeneration := ""
+	if _, ok := existingCopy.Annotations[generationAnnotation]; ok {
+		expectedGeneration = existingCopy.Annotations[generationAnnotation]
+	}
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	if !*modified && expectedGeneration == fmt.Sprintf("%x", existingCopy.GetGeneration()) {
+		return false, nil
+	}
+
+	// at this point we know that we're going to perform a write.  We're just trying to get the object correct
+	toWrite := existingCopy // shallow copy so the code reads easier
+	toWrite.Spec = *required.Spec.DeepCopy()
+
+	toWrite.Annotations[generationAnnotation] = fmt.Sprintf("%x", existingCopy.GetGeneration()+1)
+
+	err = client.Update(ctx, toWrite)
+	if err != nil {
+		recorder.Event(required, corev1.EventTypeWarning, "Update failed", err.Error())
+		return false, err
+	}
+	recorder.Event(required, corev1.EventTypeNormal, "Updated successfully", "Resource was successfully updated")
+	return true, nil
+}
+
+func applyDaemonSet(ctx context.Context, client coreclientv1.Client, recorder record.EventRecorder, requiredOriginal *appsv1.DaemonSet) (bool, error) {
+	required := requiredOriginal.DeepCopy()
+	err := SetSpecHashAnnotation(&required.ObjectMeta, required.Spec)
+	if err != nil {
+		return false, err
+	}
+
+	existing := &appsv1.DaemonSet{}
+	err = client.Get(ctx, coreclientv1.ObjectKeyFromObject(required), existing)
+	if apierrors.IsNotFound(err) {
+		required.Annotations[generationAnnotation] = "1"
+		err = client.Create(ctx, required)
+		if err != nil {
+			recorder.Event(required, corev1.EventTypeWarning, "Update failed", err.Error())
+			return false, err
+		}
+		recorder.Event(required, corev1.EventTypeNormal, "Updated successfully", "Resource was successfully updated")
+		return true, nil
+	}
+	if err != nil {
+		recorder.Event(required, corev1.EventTypeWarning, "Update failed", err.Error())
+		return false, err
+	}
+
+	modified := resourcemerge.BoolPtr(false)
+	existingCopy := existing.DeepCopy()
+
+	expectedGeneration := ""
+	if _, ok := existingCopy.Annotations[generationAnnotation]; ok {
+		expectedGeneration = existingCopy.Annotations[generationAnnotation]
+	}
+
+	resourcemerge.EnsureObjectMeta(modified, &existingCopy.ObjectMeta, required.ObjectMeta)
+	if !*modified && expectedGeneration == fmt.Sprintf("%x", existingCopy.GetGeneration()) {
+		return false, nil
+	}
+
+	// at this point we know that we're going to perform a write.  We're just trying to get the object correct
+	toWrite := existingCopy // shallow copy so the code reads easier
+	toWrite.Spec = *required.Spec.DeepCopy()
+
+	toWrite.Annotations[generationAnnotation] = fmt.Sprintf("%x", existingCopy.GetGeneration()+1)
+
+	err = client.Update(ctx, toWrite)
+	if err != nil {
+		recorder.Event(required, corev1.EventTypeWarning, "Update failed", err.Error())
+		return false, err
+	}
+	recorder.Event(required, corev1.EventTypeNormal, "Updated successfully", "Resource was successfully updated")
+	return true, nil
+}

--- a/pkg/controllers/resourceapply/resourceapply_test.go
+++ b/pkg/controllers/resourceapply/resourceapply_test.go
@@ -1,0 +1,445 @@
+package resourceapply
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
+
+	appsclientv1 "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestApplyConfigMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing *corev1.ConfigMap
+		input    *corev1.ConfigMap
+
+		expectedModified bool
+	}{
+		{
+			name: "create",
+			input: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo"},
+			},
+
+			expectedModified: true,
+		},
+		{
+			name: "skip on extra label",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+			},
+			input: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo"},
+			},
+
+			expectedModified: false,
+		},
+		{
+			name: "update on missing label",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+			},
+			input: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"new": "merge"}},
+			},
+
+			expectedModified: true,
+		},
+		{
+			name: "update on mismatch data",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+			},
+			input: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo"},
+				Data: map[string]string{
+					"configmap": "value",
+				},
+			},
+
+			expectedModified: true,
+		},
+		{
+			name: "update on mismatch binary data",
+			existing: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+				Data: map[string]string{
+					"configmap": "value",
+				},
+			},
+			input: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo"},
+				Data: map[string]string{
+					"configmap": "value",
+				},
+				BinaryData: map[string][]byte{
+					"binconfigmap": []byte("value"),
+				},
+			},
+
+			expectedModified: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := fakeclient.NewClientBuilder().Build()
+			if test.existing != nil {
+				err := client.Create(context.TODO(), test.existing)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			actualModified, err := applyConfigMap(context.TODO(), client, record.NewFakeRecorder(1000), test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if test.expectedModified != actualModified {
+				t.Errorf("expected %v, got %v", test.expectedModified, actualModified)
+			}
+		})
+	}
+}
+
+func TestApplyDeployment(t *testing.T) {
+	tests := []struct {
+		name              string
+		desiredDeployment *appsv1.Deployment
+		actualDeployment  *appsv1.Deployment
+
+		expectError        bool
+		expectedUpdate     bool
+		expectedDeployment *appsv1.Deployment
+	}{
+		{
+			name:               "the deployment is created because it doesn't exist",
+			desiredDeployment:  workloadDeployment(),
+			expectedDeployment: workloadDeploymentWithDefaultSpecHash(),
+			expectedUpdate:     true,
+		},
+
+		{
+			name:               "the deployment already exists and it's up to date",
+			desiredDeployment:  workloadDeployment(),
+			actualDeployment:   workloadDeploymentWithDefaultSpecHash(),
+			expectedDeployment: workloadDeploymentWithDefaultSpecHash(),
+		},
+
+		{
+			name:              "the actual deployment was modified by a user and must be updated",
+			desiredDeployment: workloadDeployment(),
+			actualDeployment: func() *appsv1.Deployment {
+				w := workloadDeploymentWithDefaultSpecHash()
+				w.Generation = 2
+				return w
+			}(),
+			expectedDeployment: func() *appsv1.Deployment {
+				w := workloadDeploymentWithDefaultSpecHash()
+				w.Generation = 3
+				return w
+			}(),
+			expectedUpdate: true,
+		},
+
+		{
+			name: "the deployment is updated due to a change in the spec",
+			desiredDeployment: func() *appsv1.Deployment {
+				w := workloadDeployment()
+				w.Spec.Template.Finalizers = []string{"newFinalizer"}
+				return w
+			}(),
+			actualDeployment: workloadDeploymentWithDefaultSpecHash(),
+			expectedDeployment: func() *appsv1.Deployment {
+				w := workloadDeployment()
+				w.Annotations["operator.openshift.io/spec-hash"] = "5322a9feed3671ec5e7bc72c86c9b7e2f628b00e9c7c8c4c93a48ee63e8db47a"
+				w.Spec.Template.Finalizers = []string{"newFinalizer"}
+				return w
+			}(),
+			expectedUpdate: true,
+		},
+
+		{
+			name: "the deployment is updated due to a change in Labels field",
+			desiredDeployment: func() *appsv1.Deployment {
+				w := workloadDeployment()
+				w.Labels["newLabel"] = "newValue"
+				return w
+			}(),
+			actualDeployment: workloadDeploymentWithDefaultSpecHash(),
+			expectedDeployment: func() *appsv1.Deployment {
+				w := workloadDeploymentWithDefaultSpecHash()
+				w.Labels["newLabel"] = "newValue"
+				return w
+			}(),
+			expectedUpdate: true,
+		},
+
+		{
+			name: "the deployment is updated due to a change in Annotations field",
+			desiredDeployment: func() *appsv1.Deployment {
+				w := workloadDeployment()
+				w.Annotations["newAnnotation"] = "newValue"
+				return w
+			}(),
+			actualDeployment: workloadDeploymentWithDefaultSpecHash(),
+			expectedDeployment: func() *appsv1.Deployment {
+				w := workloadDeploymentWithDefaultSpecHash()
+				w.Annotations["newAnnotation"] = "newValue"
+				return w
+			}(),
+			expectedUpdate: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventRecorder := record.NewFakeRecorder(1000)
+			client := fakeclient.NewClientBuilder().Build()
+			if tt.actualDeployment != nil {
+				err := client.Create(context.TODO(), tt.actualDeployment)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			updated, err := applyDeployment(context.TODO(), client, eventRecorder, tt.desiredDeployment)
+			if tt.expectError && err == nil {
+				t.Fatal("expected to get an error")
+			}
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.expectedUpdate && !updated {
+				t.Fatal("expected ApplyDeployment to report updated=true")
+			}
+			if !tt.expectedUpdate && updated {
+				t.Fatal("expected ApplyDeployment to report updated=false")
+			}
+
+			updatedDeployment := &appsv1.Deployment{}
+			err = client.Get(context.TODO(), appsclientv1.ObjectKeyFromObject(tt.desiredDeployment), updatedDeployment)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !equality.Semantic.DeepDerivative(tt.expectedDeployment.Spec, updatedDeployment.Spec) {
+				t.Fatalf("Expected deployment: %+v, got %+v", tt.expectedDeployment, updatedDeployment)
+			}
+		})
+	}
+}
+
+func workloadDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Deployment",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "apiserver",
+			Namespace: "openshift-apiserver",
+			Labels:    map[string]string{},
+			Annotations: map[string]string{
+				generationAnnotation: "1",
+			},
+			Generation: 1,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32Ptr(3),
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "apiserver",
+							Image: "docker-registry/img",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func workloadDeploymentWithDefaultSpecHash() *appsv1.Deployment {
+	w := workloadDeployment()
+	w.Annotations[specHashAnnotation] = "9ed89f9298716b3cde992326224f46d46e84042c41f9ff5820e7811f318be99e"
+	return w
+}
+
+func TestApplyDaemonSet(t *testing.T) {
+	tests := []struct {
+		name             string
+		desiredDaemonSet *appsv1.DaemonSet
+		actualDaemonSet  *appsv1.DaemonSet
+
+		expectError       bool
+		expectedUpdate    bool
+		expectedDaemonSet *appsv1.DaemonSet
+	}{
+		{
+			name:              "the daemonset is created because it doesn't exist",
+			desiredDaemonSet:  workloadDaemonSet(),
+			expectedDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
+			expectedUpdate:    true,
+		},
+
+		{
+			name:              "the daemonset already exists and it's up to date",
+			desiredDaemonSet:  workloadDaemonSet(),
+			actualDaemonSet:   workloadDaemonSetWithDefaultSpecHash(),
+			expectedDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
+		},
+
+		{
+			name:             "the actual daemonset was modified by a user and must be updated",
+			desiredDaemonSet: workloadDaemonSet(),
+			actualDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSetWithDefaultSpecHash()
+				w.Generation = 2
+				return w
+			}(),
+			expectedDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSetWithDefaultSpecHash()
+				w.Generation = 3
+				return w
+			}(),
+			expectedUpdate: true,
+		},
+
+		{
+			name: "the daemonset is updated due to a change in the spec",
+			desiredDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSet()
+				w.Spec.Template.Finalizers = []string{"newFinalizer"}
+				return w
+			}(),
+			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
+			expectedDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSet()
+				w.Annotations["operator.openshift.io/spec-hash"] = "5322a9feed3671ec5e7bc72c86c9b7e2f628b00e9c7c8c4c93a48ee63e8db47a"
+				w.Spec.Template.Finalizers = []string{"newFinalizer"}
+				return w
+			}(),
+			expectedUpdate: true,
+		},
+
+		{
+			name: "the daemonset is updated due to a change in Labels field",
+			desiredDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSet()
+				w.Labels["newLabel"] = "newValue"
+				return w
+			}(),
+			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
+			expectedDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSetWithDefaultSpecHash()
+				w.Labels["newLabel"] = "newValue"
+				return w
+			}(),
+			expectedUpdate: true,
+		},
+
+		{
+			name: "the daemonset is updated due to a change in Annotations field",
+			desiredDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSet()
+				w.Annotations["newAnnotation"] = "newValue"
+				return w
+			}(),
+			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
+			expectedDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSetWithDefaultSpecHash()
+				w.Annotations["newAnnotation"] = "newValue"
+				return w
+			}(),
+			expectedUpdate: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eventRecorder := record.NewFakeRecorder(1000)
+			client := fakeclient.NewClientBuilder().Build()
+			if tt.actualDaemonSet != nil {
+				err := client.Create(context.TODO(), tt.actualDaemonSet)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			updated, err := applyDaemonSet(context.TODO(), client, eventRecorder, tt.desiredDaemonSet)
+			if tt.expectError && err == nil {
+				t.Fatal("expected to get an error")
+			}
+			if !tt.expectError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.expectedUpdate && !updated {
+				t.Fatal("expected ApplyDaemonSet to report updated=true")
+			}
+			if !tt.expectedUpdate && updated {
+				t.Fatal("expected ApplyDaemonSet to report updated=false")
+			}
+
+			updatedDaemonSet := &appsv1.DaemonSet{}
+			err = client.Get(context.TODO(), appsclientv1.ObjectKeyFromObject(tt.desiredDaemonSet), updatedDaemonSet)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !equality.Semantic.DeepDerivative(tt.expectedDaemonSet.Spec, updatedDaemonSet.Spec) {
+				t.Fatalf("Expected DaemonSet: %+v, got %+v", tt.expectedDaemonSet, updatedDaemonSet)
+			}
+		})
+	}
+}
+
+func workloadDaemonSet() *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "DaemonSet",
+			APIVersion: "apps/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "apiserver",
+			Namespace: "openshift-apiserver",
+			Labels:    map[string]string{},
+			Annotations: map[string]string{
+				generationAnnotation: "1",
+			},
+			Generation: 1,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{},
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "apiserver",
+							Image: "docker-registry/img",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func workloadDaemonSetWithDefaultSpecHash() *appsv1.DaemonSet {
+	w := workloadDaemonSet()
+	w.Annotations[specHashAnnotation] = "ebe199e4e68c8ba52c7723e988895cde2ea804e8d0691d130e689f5168721bd1"
+	return w
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/admissionregistration.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/admissionregistration.go
@@ -1,0 +1,51 @@
+package resourcemerge
+
+import (
+	operatorsv1 "github.com/openshift/api/operator/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ExpectedMutatingWebhooksConfiguration returns last applied generation for MutatingWebhookConfiguration resource registered in operator
+func ExpectedMutatingWebhooksConfiguration(name string, previousGenerations []operatorsv1.GenerationStatus) int64 {
+	generation := GenerationFor(previousGenerations, schema.GroupResource{Group: admissionregistrationv1.SchemeGroupVersion.Group, Resource: "mutatingwebhookconfigurations"}, "", name)
+	if generation != nil {
+		return generation.LastGeneration
+	}
+	return -1
+}
+
+// SetMutatingWebhooksConfigurationGeneration updates operator generation status list with last applied generation for provided MutatingWebhookConfiguration resource
+func SetMutatingWebhooksConfigurationGeneration(generations *[]operatorsv1.GenerationStatus, actual *admissionregistrationv1.MutatingWebhookConfiguration) {
+	if actual == nil {
+		return
+	}
+	SetGeneration(generations, operatorsv1.GenerationStatus{
+		Group:          admissionregistrationv1.SchemeGroupVersion.Group,
+		Resource:       "mutatingwebhookconfigurations",
+		Name:           actual.Name,
+		LastGeneration: actual.ObjectMeta.Generation,
+	})
+}
+
+// ExpectedValidatingWebhooksConfiguration returns last applied generation for ValidatingWebhookConfiguration resource registered in operator
+func ExpectedValidatingWebhooksConfiguration(name string, previousGenerations []operatorsv1.GenerationStatus) int64 {
+	generation := GenerationFor(previousGenerations, schema.GroupResource{Group: admissionregistrationv1.SchemeGroupVersion.Group, Resource: "validatingwebhookconfigurations"}, "", name)
+	if generation != nil {
+		return generation.LastGeneration
+	}
+	return -1
+}
+
+// SetValidatingWebhooksConfigurationGeneration updates operator generation status list with last applied generation for provided ValidatingWebhookConfiguration resource
+func SetValidatingWebhooksConfigurationGeneration(generations *[]operatorsv1.GenerationStatus, actual *admissionregistrationv1.ValidatingWebhookConfiguration) {
+	if actual == nil {
+		return
+	}
+	SetGeneration(generations, operatorsv1.GenerationStatus{
+		Group:          admissionregistrationv1.SchemeGroupVersion.Group,
+		Resource:       "validatingwebhookconfigurations",
+		Name:           actual.Name,
+		LastGeneration: actual.ObjectMeta.Generation,
+	})
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apiextensions.go
@@ -1,0 +1,68 @@
+package resourcemerge
+
+import (
+	"strings"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+// EnsureCustomResourceDefinitionV1Beta1 ensures that the existing matches the required.
+// modified is set to true when existing had to be updated with required.
+func EnsureCustomResourceDefinitionV1Beta1(modified *bool, existing *apiextensionsv1beta1.CustomResourceDefinition, required apiextensionsv1beta1.CustomResourceDefinition) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	// we stomp everything
+	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
+		*modified = true
+		existing.Spec = required.Spec
+	}
+}
+
+// EnsureCustomResourceDefinitionV1 ensures that the existing matches the required.
+// modified is set to true when existing had to be updated with required.
+func EnsureCustomResourceDefinitionV1(modified *bool, existing *apiextensionsv1.CustomResourceDefinition, required apiextensionsv1.CustomResourceDefinition) {
+	EnsureObjectMeta(modified, &existing.ObjectMeta, required.ObjectMeta)
+
+	// we need to match defaults
+	mimicCRDV1Defaulting(&required)
+	// we stomp everything
+	if !equality.Semantic.DeepEqual(existing.Spec, required.Spec) {
+		*modified = true
+		existing.Spec = required.Spec
+	}
+}
+
+func mimicCRDV1Defaulting(required *apiextensionsv1.CustomResourceDefinition) {
+	crd_SetDefaults_CustomResourceDefinitionSpec(&required.Spec)
+
+	if required.Spec.Conversion != nil &&
+		required.Spec.Conversion.Webhook != nil &&
+		required.Spec.Conversion.Webhook.ClientConfig != nil &&
+		required.Spec.Conversion.Webhook.ClientConfig.Service != nil {
+		crd_SetDefaults_ServiceReference(required.Spec.Conversion.Webhook.ClientConfig.Service)
+	}
+}
+
+// lifted from https://github.com/kubernetes/kubernetes/blob/v1.21.0/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/defaults.go#L42-L61
+func crd_SetDefaults_CustomResourceDefinitionSpec(obj *apiextensionsv1.CustomResourceDefinitionSpec) {
+	if len(obj.Names.Singular) == 0 {
+		obj.Names.Singular = strings.ToLower(obj.Names.Kind)
+	}
+	if len(obj.Names.ListKind) == 0 && len(obj.Names.Kind) > 0 {
+		obj.Names.ListKind = obj.Names.Kind + "List"
+	}
+	if obj.Conversion == nil {
+		obj.Conversion = &apiextensionsv1.CustomResourceConversion{
+			Strategy: apiextensionsv1.NoneConverter,
+		}
+	}
+}
+
+func crd_SetDefaults_ServiceReference(obj *apiextensionsv1.ServiceReference) {
+	if obj.Port == nil {
+		obj.Port = utilpointer.Int32Ptr(443)
+	}
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apps.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/apps.go
@@ -1,0 +1,80 @@
+package resourcemerge
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	operatorsv1 "github.com/openshift/api/operator/v1"
+)
+
+func GenerationFor(generations []operatorsv1.GenerationStatus, resource schema.GroupResource, namespace, name string) *operatorsv1.GenerationStatus {
+	for i := range generations {
+		curr := &generations[i]
+		if curr.Namespace == namespace &&
+			curr.Name == name &&
+			curr.Group == resource.Group &&
+			curr.Resource == resource.Resource {
+
+			return curr
+		}
+	}
+
+	return nil
+}
+
+func SetGeneration(generations *[]operatorsv1.GenerationStatus, newGeneration operatorsv1.GenerationStatus) {
+	if generations == nil {
+		generations = &[]operatorsv1.GenerationStatus{}
+	}
+
+	existingGeneration := GenerationFor(*generations, schema.GroupResource{Group: newGeneration.Group, Resource: newGeneration.Resource}, newGeneration.Namespace, newGeneration.Name)
+	if existingGeneration == nil {
+		*generations = append(*generations, newGeneration)
+		return
+	}
+
+	existingGeneration.LastGeneration = newGeneration.LastGeneration
+	existingGeneration.Hash = newGeneration.Hash
+}
+
+func ExpectedDeploymentGeneration(required *appsv1.Deployment, previousGenerations []operatorsv1.GenerationStatus) int64 {
+	generation := GenerationFor(previousGenerations, schema.GroupResource{Group: "apps", Resource: "deployments"}, required.Namespace, required.Name)
+	if generation != nil {
+		return generation.LastGeneration
+	}
+	return -1
+}
+
+func SetDeploymentGeneration(generations *[]operatorsv1.GenerationStatus, actual *appsv1.Deployment) {
+	if actual == nil {
+		return
+	}
+	SetGeneration(generations, operatorsv1.GenerationStatus{
+		Group:          "apps",
+		Resource:       "deployments",
+		Namespace:      actual.Namespace,
+		Name:           actual.Name,
+		LastGeneration: actual.ObjectMeta.Generation,
+	})
+}
+
+func ExpectedDaemonSetGeneration(required *appsv1.DaemonSet, previousGenerations []operatorsv1.GenerationStatus) int64 {
+	generation := GenerationFor(previousGenerations, schema.GroupResource{Group: "apps", Resource: "daemonsets"}, required.Namespace, required.Name)
+	if generation != nil {
+		return generation.LastGeneration
+	}
+	return -1
+}
+
+func SetDaemonSetGeneration(generations *[]operatorsv1.GenerationStatus, actual *appsv1.DaemonSet) {
+	if actual == nil {
+		return
+	}
+	SetGeneration(generations, operatorsv1.GenerationStatus{
+		Group:          "apps",
+		Resource:       "daemonsets",
+		Namespace:      actual.Namespace,
+		Name:           actual.Name,
+		LastGeneration: actual.ObjectMeta.Generation,
+	})
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/generic_config_merger.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/generic_config_merger.go
@@ -1,0 +1,271 @@
+package resourcemerge
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/yaml"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+// MergeConfigMap takes a configmap, the target key, special overlay funcs a list of config configs to overlay on top of each other
+// It returns the resultant configmap and a bool indicating if any changes were made to the configmap
+func MergeConfigMap(configMap *corev1.ConfigMap, configKey string, specialCases map[string]MergeFunc, configYAMLs ...[]byte) (*corev1.ConfigMap, bool, error) {
+	return MergePrunedConfigMap(nil, configMap, configKey, specialCases, configYAMLs...)
+}
+
+// MergePrunedConfigMap takes a configmap, the target key, special overlay funcs a list of config configs to overlay on top of each other
+// It returns the resultant configmap and a bool indicating if any changes were made to the configmap.
+// It roundtrips the config through the given schema.
+func MergePrunedConfigMap(schema runtime.Object, configMap *corev1.ConfigMap, configKey string, specialCases map[string]MergeFunc, configYAMLs ...[]byte) (*corev1.ConfigMap, bool, error) {
+	configBytes, err := MergePrunedProcessConfig(schema, specialCases, configYAMLs...)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if reflect.DeepEqual(configMap.Data[configKey], configBytes) {
+		return configMap, false, nil
+	}
+
+	ret := configMap.DeepCopy()
+	ret.Data[configKey] = string(configBytes)
+
+	return ret, true, nil
+}
+
+// MergeProcessConfig merges a series of config yaml files together with each later one overlaying all previous
+func MergeProcessConfig(specialCases map[string]MergeFunc, configYAMLs ...[]byte) ([]byte, error) {
+	currentConfigYAML := configYAMLs[0]
+
+	for _, currConfigYAML := range configYAMLs[1:] {
+		prevConfigJSON, err := kyaml.ToJSON(currentConfigYAML)
+		if err != nil {
+			klog.Warning(err)
+			// maybe it's just json
+			prevConfigJSON = currentConfigYAML
+		}
+		prevConfig := map[string]interface{}{}
+		if err := json.NewDecoder(bytes.NewBuffer(prevConfigJSON)).Decode(&prevConfig); err != nil {
+			return nil, err
+		}
+
+		if len(currConfigYAML) > 0 {
+			currConfigJSON, err := kyaml.ToJSON(currConfigYAML)
+			if err != nil {
+				klog.Warning(err)
+				// maybe it's just json
+				currConfigJSON = currConfigYAML
+			}
+			currConfig := map[string]interface{}{}
+			if err := json.NewDecoder(bytes.NewBuffer(currConfigJSON)).Decode(&currConfig); err != nil {
+				return nil, err
+			}
+
+			// protected against mismatched typemeta
+			prevAPIVersion, _, _ := unstructured.NestedString(prevConfig, "apiVersion")
+			prevKind, _, _ := unstructured.NestedString(prevConfig, "kind")
+			currAPIVersion, _, _ := unstructured.NestedString(currConfig, "apiVersion")
+			currKind, _, _ := unstructured.NestedString(currConfig, "kind")
+			currGVKSet := len(currAPIVersion) > 0 || len(currKind) > 0
+			gvkMismatched := currAPIVersion != prevAPIVersion || currKind != prevKind
+			if currGVKSet && gvkMismatched {
+				return nil, fmt.Errorf("%v/%v does not equal %v/%v", currAPIVersion, currKind, prevAPIVersion, prevKind)
+			}
+
+			if err := mergeConfig(prevConfig, currConfig, "", specialCases); err != nil {
+				return nil, err
+			}
+		}
+
+		currentConfigYAML, err = runtime.Encode(unstructured.UnstructuredJSONScheme, &unstructured.Unstructured{Object: prevConfig})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return currentConfigYAML, nil
+}
+
+// MergePrunedProcessConfig merges a series of config yaml files together with each later one overlaying all previous.
+// The result is roundtripped through the given schema if it is non-nil.
+func MergePrunedProcessConfig(schema runtime.Object, specialCases map[string]MergeFunc, configYAMLs ...[]byte) ([]byte, error) {
+	bs, err := MergeProcessConfig(specialCases, configYAMLs...)
+	if err != nil {
+		return nil, err
+	}
+
+	if schema == nil {
+		return bs, nil
+	}
+
+	// roundtrip through the schema
+	typed := schema.DeepCopyObject()
+	if err := yaml.Unmarshal(bs, typed); err != nil {
+		return nil, err
+	}
+	typedBytes, err := json.Marshal(typed)
+	if err != nil {
+		return nil, err
+	}
+	var untypedJSON map[string]interface{}
+	if err := json.Unmarshal(typedBytes, &untypedJSON); err != nil {
+		return nil, err
+	}
+
+	// and intersect output with input because we cannot rely on omitempty in the schema
+	inputBytes, err := yaml.YAMLToJSON(bs)
+	if err != nil {
+		return nil, err
+	}
+	var inputJSON map[string]interface{}
+	if err := json.Unmarshal(inputBytes, &inputJSON); err != nil {
+		return nil, err
+	}
+	return json.Marshal(intersectJSON(inputJSON, untypedJSON))
+}
+
+type MergeFunc func(dst, src interface{}, currentPath string) (interface{}, error)
+
+var _ MergeFunc = RemoveConfig
+
+// RemoveConfig is a merge func that elimintes an entire path from the config
+func RemoveConfig(dst, src interface{}, currentPath string) (interface{}, error) {
+	return dst, nil
+}
+
+// mergeConfig overwrites entries in curr by additional.  It modifies curr.
+func mergeConfig(curr, additional map[string]interface{}, currentPath string, specialCases map[string]MergeFunc) error {
+	for additionalKey, additionalVal := range additional {
+		fullKey := currentPath + "." + additionalKey
+		specialCase, ok := specialCases[fullKey]
+		if ok {
+			var err error
+			curr[additionalKey], err = specialCase(curr[additionalKey], additionalVal, currentPath)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+
+		currVal, ok := curr[additionalKey]
+		if !ok {
+			curr[additionalKey] = additionalVal
+			continue
+		}
+
+		// only some scalars are accepted
+		switch castVal := additionalVal.(type) {
+		case map[string]interface{}:
+			currValAsMap, ok := currVal.(map[string]interface{})
+			if !ok {
+				currValAsMap = map[string]interface{}{}
+				curr[additionalKey] = currValAsMap
+			}
+
+			err := mergeConfig(currValAsMap, castVal, fullKey, specialCases)
+			if err != nil {
+				return err
+			}
+			continue
+
+		default:
+			if err := unstructured.SetNestedField(curr, castVal, additionalKey); err != nil {
+				return err
+			}
+		}
+
+	}
+
+	return nil
+}
+
+// jsonIntersection returns the intersection of both JSON object,
+// preferring the values of the first argument.
+func intersectJSON(x1, x2 map[string]interface{}) map[string]interface{} {
+	if x1 == nil || x2 == nil {
+		return nil
+	}
+	ret := map[string]interface{}{}
+	for k, v1 := range x1 {
+		v2, ok := x2[k]
+		if !ok {
+			continue
+		}
+		ret[k] = intersectValue(v1, v2)
+	}
+	return ret
+}
+
+func intersectArray(x1, x2 []interface{}) []interface{} {
+	if x1 == nil || x2 == nil {
+		return nil
+	}
+	ret := make([]interface{}, 0, len(x1))
+	for i := range x1 {
+		if i >= len(x2) {
+			break
+		}
+		ret = append(ret, intersectValue(x1[i], x2[i]))
+	}
+	return ret
+}
+
+func intersectValue(x1, x2 interface{}) interface{} {
+	switch x1 := x1.(type) {
+	case map[string]interface{}:
+		x2, ok := x2.(map[string]interface{})
+		if !ok {
+			return x1
+		}
+		return intersectJSON(x1, x2)
+	case []interface{}:
+		x2, ok := x2.([]interface{})
+		if !ok {
+			return x1
+		}
+		return intersectArray(x1, x2)
+	default:
+		return x1
+	}
+}
+
+// IsRequiredConfigPresent can check an observedConfig to see if certain required paths are present in that config.
+// This allows operators to require certain configuration to be observed before proceeding to honor a configuration or roll it out.
+func IsRequiredConfigPresent(config []byte, requiredPaths [][]string) error {
+	if len(config) == 0 {
+		return fmt.Errorf("no observedConfig")
+	}
+
+	existingConfig := map[string]interface{}{}
+	if err := json.NewDecoder(bytes.NewBuffer(config)).Decode(&existingConfig); err != nil {
+		return fmt.Errorf("error parsing config, %v", err)
+	}
+
+	for _, requiredPath := range requiredPaths {
+		configVal, found, err := unstructured.NestedFieldNoCopy(existingConfig, requiredPath...)
+		if err != nil {
+			return fmt.Errorf("error reading %v from config, %v", strings.Join(requiredPath, "."), err)
+		}
+		if !found {
+			return fmt.Errorf("%v missing from config", strings.Join(requiredPath, "."))
+		}
+		if configVal == nil {
+			return fmt.Errorf("%v null in config", strings.Join(requiredPath, "."))
+		}
+		if configValSlice, ok := configVal.([]interface{}); ok && len(configValSlice) == 0 {
+			return fmt.Errorf("%v empty in config", strings.Join(requiredPath, "."))
+		}
+		if configValString, ok := configVal.(string); ok && len(configValString) == 0 {
+			return fmt.Errorf("%v empty in config", strings.Join(requiredPath, "."))
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/object_merger.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/resource/resourcemerge/object_merger.go
@@ -1,0 +1,277 @@
+package resourcemerge
+
+import (
+	"reflect"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// EnsureObjectMeta writes namespace, name, labels, and annotations.  Don't set other things here.
+// TODO finalizer support maybe?
+func EnsureObjectMeta(modified *bool, existing *metav1.ObjectMeta, required metav1.ObjectMeta) {
+	SetStringIfSet(modified, &existing.Namespace, required.Namespace)
+	SetStringIfSet(modified, &existing.Name, required.Name)
+	MergeMap(modified, &existing.Labels, required.Labels)
+	MergeMap(modified, &existing.Annotations, required.Annotations)
+	MergeOwnerRefs(modified, &existing.OwnerReferences, required.OwnerReferences)
+}
+
+// WithCleanLabelsAndAnnotations cleans the metadata off the removal annotations/labels/ownerrefs
+// (those that end with trailing "-")
+func WithCleanLabelsAndAnnotations(obj metav1.Object) metav1.Object {
+	obj.SetAnnotations(cleanRemovalKeys(obj.GetAnnotations()))
+	obj.SetLabels(cleanRemovalKeys(obj.GetLabels()))
+	obj.SetOwnerReferences(cleanRemovalOwnerRefs(obj.GetOwnerReferences()))
+	return obj
+}
+
+func cleanRemovalKeys(required map[string]string) map[string]string {
+	for k := range required {
+		if strings.HasSuffix(k, "-") {
+			delete(required, k)
+		}
+	}
+	return required
+}
+
+func stringPtr(val string) *string {
+	return &val
+}
+
+func SetString(modified *bool, existing *string, required string) {
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func SetStringIfSet(modified *bool, existing *string, required string) {
+	if len(required) == 0 {
+		return
+	}
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func setStringPtr(modified *bool, existing **string, required *string) {
+	if *existing == nil || (required == nil && *existing != nil) {
+		*modified = true
+		*existing = required
+		return
+	}
+	SetString(modified, *existing, *required)
+}
+
+func SetStringSlice(modified *bool, existing *[]string, required []string) {
+	if !reflect.DeepEqual(required, *existing) {
+		*existing = required
+		*modified = true
+	}
+}
+
+func SetStringSliceIfSet(modified *bool, existing *[]string, required []string) {
+	if required == nil {
+		return
+	}
+	if !reflect.DeepEqual(required, *existing) {
+		*existing = required
+		*modified = true
+	}
+}
+
+func BoolPtr(val bool) *bool {
+	return &val
+}
+
+func SetBool(modified *bool, existing *bool, required bool) {
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func setBoolPtr(modified *bool, existing **bool, required *bool) {
+	if *existing == nil || (required == nil && *existing != nil) {
+		*modified = true
+		*existing = required
+		return
+	}
+	SetBool(modified, *existing, *required)
+}
+
+func int64Ptr(val int64) *int64 {
+	return &val
+}
+
+func SetInt32(modified *bool, existing *int32, required int32) {
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func SetInt32IfSet(modified *bool, existing *int32, required int32) {
+	if required == 0 {
+		return
+	}
+
+	SetInt32(modified, existing, required)
+}
+
+func SetInt64(modified *bool, existing *int64, required int64) {
+	if required != *existing {
+		*existing = required
+		*modified = true
+	}
+}
+
+func setInt64Ptr(modified *bool, existing **int64, required *int64) {
+	if *existing == nil || (required == nil && *existing != nil) {
+		*modified = true
+		*existing = required
+		return
+	}
+	SetInt64(modified, *existing, *required)
+}
+
+func MergeMap(modified *bool, existing *map[string]string, required map[string]string) {
+	if *existing == nil {
+		*existing = map[string]string{}
+	}
+	for k, v := range required {
+		actualKey := k
+		removeKey := false
+
+		// if "required" map contains a key with "-" as suffix, remove that
+		// key from the existing map instead of replacing the value
+		if strings.HasSuffix(k, "-") {
+			removeKey = true
+			actualKey = strings.TrimRight(k, "-")
+		}
+
+		if existingV, ok := (*existing)[actualKey]; removeKey {
+			if !ok {
+				continue
+			}
+			// value found -> it should be removed
+			delete(*existing, actualKey)
+			*modified = true
+
+		} else if !ok || v != existingV {
+			*modified = true
+			(*existing)[actualKey] = v
+		}
+	}
+}
+
+func SetMapStringString(modified *bool, existing *map[string]string, required map[string]string) {
+	if *existing == nil {
+		*existing = map[string]string{}
+	}
+
+	if !reflect.DeepEqual(*existing, required) {
+		*existing = required
+	}
+}
+
+func SetMapStringStringIfSet(modified *bool, existing *map[string]string, required map[string]string) {
+	if required == nil {
+		return
+	}
+	if *existing == nil {
+		*existing = map[string]string{}
+	}
+
+	if !reflect.DeepEqual(*existing, required) {
+		*existing = required
+	}
+}
+
+func MergeOwnerRefs(modified *bool, existing *[]metav1.OwnerReference, required []metav1.OwnerReference) {
+	if *existing == nil {
+		*existing = []metav1.OwnerReference{}
+	}
+
+	for _, o := range required {
+		removeOwner := false
+
+		// if "required" ownerRefs contain an owner.UID with "-" as suffix, remove that
+		// ownerRef from the existing ownerRefs instead of replacing the value
+		// NOTE: this is the same format as kubectl annotate and kubectl label
+		if strings.HasSuffix(string(o.UID), "-") {
+			removeOwner = true
+		}
+
+		existedIndex := 0
+
+		for existedIndex < len(*existing) {
+			if ownerRefMatched(o, (*existing)[existedIndex]) {
+				break
+			}
+			existedIndex++
+		}
+
+		if existedIndex == len(*existing) {
+			// There is no matched ownerref found, append the ownerref
+			// if it is not to be removed.
+			if !removeOwner {
+				*existing = append(*existing, o)
+				*modified = true
+			}
+			continue
+		}
+
+		if removeOwner {
+			*existing = append((*existing)[:existedIndex], (*existing)[existedIndex+1:]...)
+			*modified = true
+			continue
+		}
+
+		if !reflect.DeepEqual(o, (*existing)[existedIndex]) {
+			(*existing)[existedIndex] = o
+			*modified = true
+		}
+	}
+}
+
+func ownerRefMatched(existing, required metav1.OwnerReference) bool {
+	if existing.Name != required.Name {
+		return false
+	}
+
+	if existing.Kind != required.Kind {
+		return false
+	}
+
+	existingGV, err := schema.ParseGroupVersion(existing.APIVersion)
+
+	if err != nil {
+		return false
+	}
+
+	requiredGV, err := schema.ParseGroupVersion(required.APIVersion)
+
+	if err != nil {
+		return false
+	}
+
+	if existingGV.Group != requiredGV.Group {
+		return false
+	}
+
+	return true
+}
+
+func cleanRemovalOwnerRefs(required []metav1.OwnerReference) []metav1.OwnerReference {
+	for k := 0; k < len(required); k++ {
+		if strings.HasSuffix(string(required[k].UID), "-") {
+			required = append(required[:k], required[k+1:]...)
+			k--
+		}
+	}
+	return required
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -124,6 +124,7 @@ github.com/openshift/api/operator/v1
 ## explicit
 github.com/openshift/library-go/pkg/cloudprovider
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
+github.com/openshift/library-go/pkg/operator/resource/resourcemerge
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
Currently the operator uses Server-Side Apply (SSA)[1] to manage its resources. Unfortunately, this approach has some drawbacks as it allows users to modify resources independently from the operator.

To prevent this behavior, this commit adds custom apply functions inspired by ones from resourseapply module in library-go[2].

[1] https://kubernetes.io/docs/reference/using-api/server-side-apply/
[2] https://github.com/openshift/library-go/tree/master/pkg/operator/resource/resourceapply