### PR TITLE
Bug 2017565: [OCPCLOUD-1306] Add user defined trusted CA from cloud-config to ccm-trusted-ca bundle 

### DIFF
--- a/pkg/controllers/cloud_config_sync_controller.go
+++ b/pkg/controllers/cloud_config_sync_controller.go
@@ -22,8 +22,7 @@ import (
 const (
 	managedCloudConfigMapName = "kube-cloud-config"
 
-	cloudConfigMapName = "cloud-conf"
-	defaultConfigKey   = "cloud.conf"
+	defaultConfigKey = "cloud.conf"
 )
 
 type CloudConfigReconciler struct {
@@ -68,7 +67,7 @@ func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	targetCM := &corev1.ConfigMap{}
 	targetConfigMapKey := client.ObjectKey{
 		Namespace: r.TargetNamespace,
-		Name:      cloudConfigMapName,
+		Name:      syncedCloudConfigMapName,
 	}
 
 	// If the config does not exist, it will be created later, so we can ignore a Not Found error
@@ -116,7 +115,7 @@ func (r *CloudConfigReconciler) isCloudConfigEqual(source *corev1.ConfigMap, tar
 }
 
 func (r *CloudConfigReconciler) syncCloudConfigData(ctx context.Context, source *corev1.ConfigMap, target *corev1.ConfigMap) error {
-	target.SetName(cloudConfigMapName)
+	target.SetName(syncedCloudConfigMapName)
 	target.SetNamespace(r.TargetNamespace)
 	target.Data = source.Data
 	target.BinaryData = source.BinaryData

--- a/pkg/controllers/common_consts.go
+++ b/pkg/controllers/common_consts.go
@@ -8,5 +8,7 @@ const (
 	OpenshiftConfigNamespace        = "openshift-config"
 	OpenshiftManagedConfigNamespace = "openshift-config-managed"
 
+	syncedCloudConfigMapName = "cloud-conf"
+
 	proxyResourceName = "cluster"
 )

--- a/pkg/controllers/watch_predicates.go
+++ b/pkg/controllers/watch_predicates.go
@@ -61,7 +61,7 @@ func featureGatePredicates() predicate.Funcs {
 func ownCloudConfigPredicate(targetNamespace string) predicate.Funcs {
 	isOwnCloudConfigMap := func(obj runtime.Object) bool {
 		configMap, ok := obj.(*corev1.ConfigMap)
-		return ok && configMap.GetNamespace() == targetNamespace && configMap.GetName() == cloudConfigMapName
+		return ok && configMap.GetNamespace() == targetNamespace && configMap.GetName() == syncedCloudConfigMapName
 	}
 
 	return predicate.Funcs{

--- a/pkg/util/trustbundle.go
+++ b/pkg/util/trustbundle.go
@@ -10,21 +10,20 @@ import (
 
 const (
 	// certPEMBlock is the type taken from the preamble of a PEM-encoded structure.
-	certPEMBlock                = "CERTIFICATE"
-	trustedCABundleConfigMapKey = "ca-bundle.crt"
+	certPEMBlock = "CERTIFICATE"
 )
 
 // TrustBundleConfigMap validates that ConfigMap contains a
-// trust bundle named "ca-bundle.crt" and that "ca-bundle.crt"
+// trust bundle named aa "caBundleKey" argument and that "caBundleKey"
 // contains one or more valid PEM encoded certificates, returning
-// a byte slice of "ca-bundle.crt" contents upon success.
-func TrustBundleConfigMap(cfgMap *corev1.ConfigMap) ([]*x509.Certificate, []byte, error) {
-	if _, ok := cfgMap.Data[trustedCABundleConfigMapKey]; !ok {
-		return nil, nil, fmt.Errorf("ConfigMap %q is missing %q", cfgMap.Name, trustedCABundleConfigMapKey)
+// a byte slice of "caBundleKey" contents upon success.
+func TrustBundleConfigMap(cfgMap *corev1.ConfigMap, caBundleKey string) ([]*x509.Certificate, []byte, error) {
+	if _, ok := cfgMap.Data[caBundleKey]; !ok {
+		return nil, nil, fmt.Errorf("ConfigMap %q is missing %q", cfgMap.Name, caBundleKey)
 	}
-	trustBundleData := []byte(cfgMap.Data[trustedCABundleConfigMapKey])
+	trustBundleData := []byte(cfgMap.Data[caBundleKey])
 	if len(trustBundleData) == 0 {
-		return nil, nil, fmt.Errorf("data key %q is empty from ConfigMap %q", trustedCABundleConfigMapKey, cfgMap.Name)
+		return nil, nil, fmt.Errorf("data key %q is empty from ConfigMap %q", caBundleKey, cfgMap.Name)
 	}
 	certBundle, err := CertificateData(trustBundleData)
 	if err != nil {


### PR DESCRIPTION
Additional trusted CA from cloud-config should also be counted during
ccm-trusted-ca sync procedure. Due to OCP installer nuances,
'additionalTrustBundle' not always ends up in the proxy object.

For handling such situation this patch introduces support of 'ca-bundle.pem'
key in cloud-config. CA from there will be added to ccm-trusted-ca along with
additional CA bundle which reffered by proxy object.

For additional context see:
openshift/installer#5251 (comment)