### PR TITLE
Add exclusion annotation for hosted deployments

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_00_namespace.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_00_namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   labels:
@@ -20,6 +21,7 @@ metadata:
   annotations:
     include.release.openshift.io/single-node-developer: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
   labels:

--- a/manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 data:
   images.json: >
     {

--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16,6 +17,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - config.openshift.io
@@ -73,6 +75,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups:
       - ""
@@ -116,6 +119,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups:
       - ""
@@ -135,6 +139,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -153,6 +158,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups:
       - ""
@@ -172,6 +178,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -189,6 +196,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: ClusterRole
   name: system:openshift:operator:cloud-controller-manager
@@ -207,6 +215,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: Role
   name: cluster-cloud-controller-manager
@@ -225,6 +234,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: ClusterRole
   name: admin

--- a/manifests/0000_26_cloud-controller-manager-operator_03_rbac_provider.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_03_rbac_provider.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -17,6 +18,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: Role
   name: cloud-controller-manager
@@ -35,6 +37,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups:
       - coordination.k8s.io
@@ -63,6 +66,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""
@@ -168,6 +172,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: ClusterRole
   name: cloud-controller-manager
@@ -186,6 +191,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
@@ -202,6 +208,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   name: cloud-node-manager
   namespace: openshift-cloud-controller-manager
 
@@ -213,6 +220,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -229,6 +237,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     k8s-app: cloud-manager-operator
 spec:
@@ -140,6 +141,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
     release.openshift.io/delete: "true"
   labels:
     k8s-app: cloud-manager-operator

--- a/manifests/0000_26_cloud-controller-manager-operator_13_credentialsrequest-openstack.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_13_credentialsrequest-openstack.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   secretRef:
     name: openstack-cloud-credentials

--- a/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   secretRef:
     name: azure-cloud-credentials

--- a/manifests/0000_26_cloud-controller-manager-operator_15_credentialsrequest-ibm.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_15_credentialsrequest-ibm.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   secretRef:
     name: ibm-cloud-credentials


### PR DESCRIPTION
Configures the CVO to exclude manifests in deployments with external control planes
See https://github.com/openshift/cluster-version-operator/pull/252