### PR TITLE
Remove invalid feature-gate option from ccm deployment

### DIFF
--- a/pkg/cloud/ibm/assets/deployment.yaml
+++ b/pkg/cloud/ibm/assets/deployment.yaml
@@ -75,7 +75,6 @@ spec:
             --configure-cloud-routes=false \
             --cloud-provider=ibm \
             --cloud-config=/etc/ibm/cloud.conf \
-            --feature-gates=IPv6DualStack=false \
             --profiling=false \
             --leader-elect=true \
             --leader-elect-lease-duration=137s \


### PR DESCRIPTION
--feature-gates=IPv6DualStack=false  is no longer a valid option in kube 1.23