### PR TITLE
Remove unused PersistentVolume RBAC

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_03_rbac_provider.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_03_rbac_provider.yaml
@@ -119,15 +119,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - persistentvolumes
-  verbs:
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - ""
-  resources:
   - endpoints
   verbs:
   - create


### PR DESCRIPTION
This was raised by our product security team. Looking at the cloud-provider library, the only usage of PersistentVolume is a [labelling interface](https://github.com/kubernetes/cloud-provider/blob/d3ee5ab10d70e1f304b00c1e835000ccea6df1b4/cloud.go#L277-L279). This is implemented by some of the cloud providers (eg AWS, Azure and GCP) but not others (eg IBM). 

Having checked the `k8s.io/cloud-provider` repository and the providers for IBM, AWS, Azure and GCP, I can't see this being called anywhere, and as such, I'm pretty sure we don't need these permissions.