### PR TITLE
Allow Azure node manager to be deployed on Windows

### DIFF
--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -24,8 +24,6 @@ spec:
       priorityClassName: system-node-critical
       serviceAccountName: cloud-node-manager
       hostNetwork: true
-      nodeSelector:
-        kubernetes.io/os: linux
       tolerations:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
@@ -44,6 +42,10 @@ spec:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
           operator: Exists
+        - effect: "NoSchedule"
+          key: "os"
+          operator: "Equal"
+          value: "Windows"
       containers:
         - name: cloud-node-manager
           image: {{ .images.CloudNodeManager }}


### PR DESCRIPTION
This commit removes restrictions that doesn't allow the manager to work on Windows machines.