### PR TITLE
[Bug 2019219] IBMCloud: Add RG IAM permissions

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_15_credentialsrequest-ibm.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_15_credentialsrequest-ibm.yaml
@@ -16,10 +16,15 @@ spec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: IBMCloudProviderSpec
     policies:
-    - roles:
+    - attributes:
+      - name: resourceType
+        value: resource-group
+      roles:
+      - "crn:v1:bluemix:public:iam::::role:Viewer"
+    - attributes:
+      - name: serviceName
+        value: is
+      roles:
       - "crn:v1:bluemix:public:iam::::role:Editor"
       - "crn:v1:bluemix:public:iam::::role:Operator"
       - "crn:v1:bluemix:public:iam::::role:Viewer"
-      attributes:
-      - name: "serviceName"
-        value: "is"


### PR DESCRIPTION
Add IAM permissions for ResourceGroups to the IBM Cloud
CredentialsRequests, due to changes in requirements for the IBM
Cloud CCM.

Partial: https://bugzilla.redhat.com/show_bug.cgi?id=2019219