### PR TITLE
Bug 2025884: Inject openstack CCM image within deployment template

### DIFF
--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -45,7 +45,7 @@ spec:
           effect: NoSchedule
       containers:
         - name: cloud-controller-manager
-          image: quay.io/openshift/origin-openstack-cloud-controller-manager
+          image: {{ .images.CloudControllerManager }}
           imagePullPolicy: "IfNotPresent"
           env:
             - name: CLOUD_CONFIG


### PR DESCRIPTION
We are supposed to substitute the image based on the image references we are passed. This is implemented using templating in all of the other providers, but it was missed within OSP.

CC @mdbooth 