### PR TITLE
Alibaba Cloud Provider: fix the path to the binary to match the build…

### DIFF
--- a/pkg/cloud/alibaba/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/alibaba/assets/cloud-controller-manager-deployment.yaml
@@ -57,7 +57,7 @@ spec:
               if [[ -f /etc/kubernetes/apiserver-url.env ]]; then
                 source /etc/kubernetes/apiserver-url.env
               fi
-              exec /cloud-controller-manager \
+              exec /bin/alibaba-cloud-controller-manager \
               --allow-untagged-cloud=true \
               --leader-elect=true \
               --leader-elect-lease-duration=137s \


### PR DESCRIPTION
… from the Dockerfile

Since there has been a small amount of churn there is a mismatch in the name and path of the binary from the Dockerfile.

Here is the corresponding Dockerfile:
https://github.com/openshift/cloud-provider-alibaba-cloud/blob/master/openshift-hack/images/Dockerfile.openshift#L12