### PR TITLE
[OCPCLOUD-1307] Refactor CCCMO cluster-operator resource handling

### DIFF
--- a/cmd/cluster-cloud-controller-manager-operator/main.go
+++ b/cmd/cluster-cloud-controller-manager-operator/main.go
@@ -128,12 +128,14 @@ func main() {
 	}
 
 	if err = (&controllers.CloudOperatorReconciler{
-		Client:           mgr.GetClient(),
-		Scheme:           mgr.GetScheme(),
-		Recorder:         mgr.GetEventRecorderFor("cloud-controller-manager-operator"),
-		ReleaseVersion:   getReleaseVersion(),
-		ManagedNamespace: *managedNamespace,
-		ImagesFile:       *imagesFile,
+		ClusterOperatorStatusClient: controllers.ClusterOperatorStatusClient{
+			Client:           mgr.GetClient(),
+			Recorder:         mgr.GetEventRecorderFor("cloud-controller-manager-operator"),
+			ReleaseVersion:   getReleaseVersion(),
+			ManagedNamespace: *managedNamespace,
+		},
+		Scheme:     mgr.GetScheme(),
+		ImagesFile: *imagesFile,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ClusterOperator")
 		os.Exit(1)

--- a/cmd/config-sync-controllers/main.go
+++ b/cmd/config-sync-controllers/main.go
@@ -130,10 +130,12 @@ func main() {
 	}
 
 	if err = (&controllers.TrustedCABundleReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("cloud-controller-manager-operator-ca-sync-controller"),
-		TargetNamespace: *managedNamespace,
+		ClusterOperatorStatusClient: controllers.ClusterOperatorStatusClient{
+			Client:           mgr.GetClient(),
+			Recorder:         mgr.GetEventRecorderFor("cloud-controller-manager-operator-ca-sync-controller"),
+			ManagedNamespace: *managedNamespace,
+		},
+		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create Trusted CA sync controller", "controller", "ClusterOperator")
 		os.Exit(1)

--- a/cmd/config-sync-controllers/main.go
+++ b/cmd/config-sync-controllers/main.go
@@ -118,10 +118,12 @@ func main() {
 	}
 
 	if err = (&controllers.CloudConfigReconciler{
-		Client:          mgr.GetClient(),
-		Scheme:          mgr.GetScheme(),
-		Recorder:        mgr.GetEventRecorderFor("cloud-controller-manager-operator-cloud-config-sync-controller"),
-		TargetNamespace: *managedNamespace,
+		ClusterOperatorStatusClient: controllers.ClusterOperatorStatusClient{
+			Client:           mgr.GetClient(),
+			Recorder:         mgr.GetEventRecorderFor("cloud-controller-manager-operator-cloud-config-sync-controller"),
+			ManagedNamespace: *managedNamespace,
+		},
+		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create cloud-config sync controller", "controller", "ClusterOperator")
 		os.Exit(1)

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -185,6 +185,16 @@ var _ = Describe("Cloud config sync controller", func() {
 		mgrCtxCancel()
 		Eventually(mgrStopped, timeout).Should(BeClosed())
 
+		co := &configv1.ClusterOperator{}
+		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
+		if err == nil || !apierrors.IsNotFound(err) {
+			Eventually(func() bool {
+				err := cl.Delete(context.Background(), co)
+				return err == nil || apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		}
+		Eventually(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co))).Should(BeTrue())
+
 		By("Cleanup resources")
 		deleteOptions := &client.DeleteOptions{
 			GracePeriodSeconds: pointer.Int64(0),
@@ -370,6 +380,16 @@ var _ = Describe("Cloud config sync reconciler", func() {
 		deleteOptions := &client.DeleteOptions{
 			GracePeriodSeconds: pointer.Int64(0),
 		}
+
+		co := &configv1.ClusterOperator{}
+		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
+		if err == nil || !apierrors.IsNotFound(err) {
+			Eventually(func() bool {
+				err := cl.Delete(context.Background(), co)
+				return err == nil || apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		}
+		Eventually(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co))).Should(BeTrue())
 
 		infra := &configv1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -146,10 +146,12 @@ var _ = Describe("Cloud config sync controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reconciler = &CloudConfigReconciler{
-			Client:          cl,
-			Scheme:          scheme.Scheme,
-			Recorder:        rec,
-			TargetNamespace: targetNamespaceName,
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Recorder:         rec,
+				ManagedNamespace: targetNamespaceName,
+			},
+			Scheme: scheme.Scheme,
 		}
 		Expect(reconciler.SetupWithManager(mgr)).To(Succeed())
 
@@ -317,9 +319,11 @@ var _ = Describe("Cloud config sync reconciler", func() {
 
 	BeforeEach(func() {
 		reconciler = &CloudConfigReconciler{
-			Client:          cl,
-			Scheme:          scheme.Scheme,
-			TargetNamespace: targetNamespaceName,
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				ManagedNamespace: targetNamespaceName,
+			},
+			Scheme: scheme.Scheme,
 		}
 
 		Expect(cl.Create(ctx, makeInfraCloudConfig())).To(Succeed())

--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -26,7 +26,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -49,13 +48,10 @@ const (
 
 // CloudOperatorReconciler reconciles a ClusterOperator object
 type CloudOperatorReconciler struct {
-	client.Client
-	Scheme           *runtime.Scheme
-	Recorder         record.EventRecorder
-	watcher          ObjectWatcher
-	ReleaseVersion   string
-	ManagedNamespace string
-	ImagesFile       string
+	ClusterOperatorStatusClient
+	Scheme     *runtime.Scheme
+	watcher    ObjectWatcher
+	ImagesFile string
 }
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list;watch;create;update;patch;delete

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Cluster Operator status controller", func() {
 
 	BeforeEach(func() {
 		operatorController = &CloudOperatorReconciler{
-			ClusterOperatorStatus: ClusterOperatorStatus{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
 				Client:           cl,
 				ManagedNamespace: defaultManagementNamespace,
 				Recorder:         record.NewFakeRecorder(32),
@@ -295,7 +295,7 @@ var _ = Describe("Component sync controller", func() {
 		operands = nil
 
 		operatorController = &CloudOperatorReconciler{
-			ClusterOperatorStatus: ClusterOperatorStatus{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
 				Client:           cl,
 				ManagedNamespace: testManagedNamespace,
 				Recorder:         record.NewFakeRecorder(32),
@@ -558,7 +558,7 @@ var _ = Describe("Apply resources should", func() {
 
 		recorder = record.NewFakeRecorder(32)
 		reconciler = &CloudOperatorReconciler{
-			ClusterOperatorStatus: ClusterOperatorStatus{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
 				Client:   cl,
 				Recorder: recorder,
 			},

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -1006,6 +1006,16 @@ var _ = Describe("Apply resources should", func() {
 	})
 
 	AfterEach(func() {
+		co := &configv1.ClusterOperator{}
+		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
+		if err == nil || !apierrors.IsNotFound(err) {
+			Eventually(func() bool {
+				err := cl.Delete(context.Background(), co)
+				return err == nil || apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		}
+		Eventually(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co))).Should(BeTrue())
+
 		for _, operand := range resources {
 			Expect(cl.Delete(context.Background(), operand)).To(Succeed())
 

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -42,10 +42,12 @@ var _ = Describe("Cluster Operator status controller", func() {
 
 	BeforeEach(func() {
 		operatorController = &CloudOperatorReconciler{
-			Client:           cl,
-			Scheme:           scheme.Scheme,
-			ManagedNamespace: defaultManagementNamespace,
-			Recorder:         record.NewFakeRecorder(32),
+			ClusterOperatorStatus: ClusterOperatorStatus{
+				Client:           cl,
+				ManagedNamespace: defaultManagementNamespace,
+				Recorder:         record.NewFakeRecorder(32),
+			},
+			Scheme: scheme.Scheme,
 		}
 		operator = &configv1.ClusterOperator{}
 		operator.SetName(clusterOperatorName)
@@ -293,12 +295,14 @@ var _ = Describe("Component sync controller", func() {
 		operands = nil
 
 		operatorController = &CloudOperatorReconciler{
-			Client:           cl,
-			Scheme:           scheme.Scheme,
-			watcher:          w,
-			ManagedNamespace: testManagedNamespace,
-			ImagesFile:       testImagesFilePath,
-			Recorder:         record.NewFakeRecorder(32),
+			ClusterOperatorStatus: ClusterOperatorStatus{
+				Client:           cl,
+				ManagedNamespace: testManagedNamespace,
+				Recorder:         record.NewFakeRecorder(32),
+			},
+			Scheme:     scheme.Scheme,
+			watcher:    w,
+			ImagesFile: testImagesFilePath,
 		}
 		originalWatcher, _ := w.(*objectWatcher)
 		watcher = mockedWatcher{watcher: originalWatcher}
@@ -554,10 +558,12 @@ var _ = Describe("Apply resources should", func() {
 
 		recorder = record.NewFakeRecorder(32)
 		reconciler = &CloudOperatorReconciler{
-			Client:   cl,
-			Scheme:   scheme.Scheme,
-			Recorder: recorder,
-			watcher:  w,
+			ClusterOperatorStatus: ClusterOperatorStatus{
+				Client:   cl,
+				Recorder: recorder,
+			},
+			Scheme:  scheme.Scheme,
+			watcher: w,
 		}
 
 		getConfigForPlatform = func(status *configv1.PlatformStatus) config.OperatorConfig {

--- a/pkg/controllers/status_test.go
+++ b/pkg/controllers/status_test.go
@@ -79,9 +79,11 @@ func TestOperatorSetStatusProgressing(t *testing.T) {
 		startTime := metav1.NewTime(time.Now().Add(-time.Second))
 
 		optr := CloudOperatorReconciler{
-			Scheme:         scheme.Scheme,
-			Recorder:       record.NewFakeRecorder(32),
-			ReleaseVersion: tc.desiredVersion,
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Recorder:       record.NewFakeRecorder(32),
+				ReleaseVersion: tc.desiredVersion,
+			},
+			Scheme: scheme.Scheme,
 		}
 
 		builder := fake.NewClientBuilder()
@@ -201,9 +203,11 @@ func TestOperatorSetStatusDegraded(t *testing.T) {
 		startTime := metav1.NewTime(time.Now().Add(-time.Second))
 
 		optr := CloudOperatorReconciler{
-			Scheme:         scheme.Scheme,
-			Recorder:       record.NewFakeRecorder(32),
-			ReleaseVersion: tc.desiredVersion,
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Recorder:       record.NewFakeRecorder(32),
+				ReleaseVersion: tc.desiredVersion,
+			},
+			Scheme: scheme.Scheme,
 		}
 
 		builder := fake.NewClientBuilder()
@@ -320,9 +324,11 @@ func TestOperatorSetStatusAvailable(t *testing.T) {
 		startTime := metav1.NewTime(time.Now().Add(-time.Second))
 
 		optr := CloudOperatorReconciler{
-			Scheme:         scheme.Scheme,
-			Recorder:       record.NewFakeRecorder(32),
-			ReleaseVersion: tc.desiredVersion,
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Recorder:       record.NewFakeRecorder(32),
+				ReleaseVersion: tc.desiredVersion,
+			},
+			Scheme: scheme.Scheme,
 		}
 
 		builder := fake.NewClientBuilder()

--- a/pkg/controllers/trusted_ca_bundle_controller_test.go
+++ b/pkg/controllers/trusted_ca_bundle_controller_test.go
@@ -86,10 +86,12 @@ var _ = Describe("Trusted CA bundle sync controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		reconciler = &TrustedCABundleReconciler{
-			Client:          cl,
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Recorder:         rec,
+				ManagedNamespace: targetNamespaceName,
+			},
 			Scheme:          scheme.Scheme,
-			Recorder:        rec,
-			TargetNamespace: targetNamespaceName,
 			trustBundlePath: systemCAValid,
 		}
 		Expect(reconciler.SetupWithManager(mgr)).To(Succeed())

--- a/pkg/controllers/trusted_ca_bundle_controller_test.go
+++ b/pkg/controllers/trusted_ca_bundle_controller_test.go
@@ -128,6 +128,16 @@ var _ = Describe("Trusted CA bundle sync controller", func() {
 			GracePeriodSeconds: pointer.Int64(0),
 		}
 
+		co := &v1.ClusterOperator{}
+		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
+		if err == nil || !apierrors.IsNotFound(err) {
+			Eventually(func() bool {
+				err := cl.Delete(context.Background(), co)
+				return err == nil || apierrors.IsNotFound(err)
+			}).Should(BeTrue())
+		}
+		Eventually(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co))).Should(BeTrue())
+
 		if proxyResource != nil {
 			Expect(cl.Delete(ctx, proxyResource, deleteOptions)).To(Succeed())
 			Eventually(


### PR DESCRIPTION
This PR moves logic from ClusterOperatorReconciler related to the status management into its own type - ClusterOperatorStatus. It allows to reuse it in other controllers.