### PR TITLE
Bug 2033489: Use a list of platforms where config sync is required

### DIFF
--- a/pkg/controllers/cloud_config_sync_controller.go
+++ b/pkg/controllers/cloud_config_sync_controller.go
@@ -136,10 +136,14 @@ func (r *CloudConfigReconciler) isCloudConfigSyncNeeded(platformStatus *configv1
 		return false, fmt.Errorf("platformStatus is required")
 	}
 	switch platformStatus.Type {
-	case configv1.AWSPlatformType, configv1.BareMetalPlatformType: // aws ccm does not use cloud-config at the moment
-		return false, nil
-	default:
+	case configv1.AzurePlatformType,
+		configv1.GCPPlatformType,
+		configv1.VSpherePlatformType,
+		configv1.AlibabaCloudPlatformType,
+		configv1.IBMCloudPlatformType:
 		return true, nil
+	default:
+		return false, nil
 	}
 }
 


### PR DESCRIPTION
Currently we have a list of platforms where cloud sync is not required. Unfortunately, if we add a platform where it's not required and it's not in the list, the operator fails to start, and the whole cluster is degraded.

It's better to create a list of the platform where the sync is necessary, and ignore the others.