### PR TITLE
Bug 2047998: Alibaba should deploy image from release payload

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,6 +6,10 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-cluster-cloud-controller-manager-operator
+  - name: alibaba-cloud-controller-manager
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-alibaba-cloud-controller-manager
   - name: aws-cloud-controller-manager
     from:
       kind: DockerImage

--- a/pkg/cloud/alibaba/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/alibaba/assets/cloud-controller-manager-deployment.yaml
@@ -71,7 +71,7 @@ spec:
               --configure-cloud-routes=false \
               --allocate-node-cidrs=false \
               --metrics-bind-addr=0
-          image: quay.io/openshift/origin-alibaba-cloud-controller-manager
+          image: {{ .images.CloudControllerManager }}
           livenessProbe:
             failureThreshold: 8
             httpGet:


### PR DESCRIPTION
The CCCMO must deploy images from the release payload and not directly from the quay repo