### PR TITLE
Fix a typo in watch predicates

### DIFF
--- a/pkg/controllers/watch_predicates.go
+++ b/pkg/controllers/watch_predicates.go
@@ -80,7 +80,7 @@ func openshiftCloudConfigMapPredicates() predicate.Funcs {
 			return false
 		}
 
-		isOpenshiftConfigNamespace := configMap.GetName() == OpenshiftConfigNamespace
+		isOpenshiftConfigNamespace := configMap.GetNamespace() == OpenshiftConfigNamespace
 		isManagedCloudConfig := configMap.GetName() == managedCloudConfigMapName && configMap.GetNamespace() == OpenshiftManagedConfigNamespace
 
 		return isOpenshiftConfigNamespace || isManagedCloudConfig


### PR DESCRIPTION
To get whether a config map belongs to the openshift config namespace we need to call `GetNamespace` and not `GetName`.