### PR TITLE
Changes to support config map sych for Power VS Platform

### DIFF
--- a/pkg/controllers/cloud_config_sync_controller.go
+++ b/pkg/controllers/cloud_config_sync_controller.go
@@ -140,7 +140,8 @@ func (r *CloudConfigReconciler) isCloudConfigSyncNeeded(platformStatus *configv1
 		configv1.GCPPlatformType,
 		configv1.VSpherePlatformType,
 		configv1.AlibabaCloudPlatformType,
-		configv1.IBMCloudPlatformType:
+		configv1.IBMCloudPlatformType,
+		configv1.PowerVSPlatformType:
 		return true, nil
 	default:
 		return false, nil


### PR DESCRIPTION
With the [changes](https://github.com/Karthik-K-N/cluster-cloud-controller-manager-operator/commit/7f9529f78edcb0117f649f7ad23b702f8539c19b) added recently the config map synch was missed for Power VS platform. This PR adds Power VS platform to list of providers which need config map sync