### PR TITLE
Bug 2055723: start watching KubeControllerManager resource

### DIFF
--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -193,6 +193,9 @@ func (r *CloudOperatorReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&source.Kind{Type: &configv1.FeatureGate{}},
 			handler.EnqueueRequestsFromMapFunc(toClusterOperator),
 			builder.WithPredicates(featureGatePredicates())).
+		Watches(&source.Kind{Type: &operatorv1.KubeControllerManager{}},
+			handler.EnqueueRequestsFromMapFunc(toClusterOperator),
+			builder.WithPredicates(kcmPredicates())).
 		Watches(&source.Channel{Source: watcher.EventStream()}, handler.EnqueueRequestsFromMapFunc(toClusterOperator))
 
 	return build.Complete(r)

--- a/pkg/controllers/watch_predicates.go
+++ b/pkg/controllers/watch_predicates.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,6 +56,20 @@ func featureGatePredicates() predicate.Funcs {
 		UpdateFunc:  func(e event.UpdateEvent) bool { return isFeatureGateCluster(e.ObjectNew) },
 		GenericFunc: func(e event.GenericEvent) bool { return isFeatureGateCluster(e.Object) },
 		DeleteFunc:  func(e event.DeleteEvent) bool { return isFeatureGateCluster(e.Object) },
+	}
+}
+
+func kcmPredicates() predicate.Funcs {
+	isKCMCluster := func(obj runtime.Object) bool {
+		kcm, ok := obj.(*operatorv1.KubeControllerManager)
+		return ok && kcm.GetName() == kcmResourceName
+	}
+
+	return predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return isKCMCluster(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return isKCMCluster(e.ObjectNew) },
+		GenericFunc: func(e event.GenericEvent) bool { return isKCMCluster(e.Object) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return isKCMCluster(e.Object) },
 	}
 }
 


### PR DESCRIPTION
CCM operator deploys required resources only if KCM doesn't own related controllers. To check it CCM operator looks for
CloudControllerOwner condition with false value on KCM CR in its cache.

Currently we don't watch KCM, and therefore this condition is not present in the cache.

To fix it, this commit adds KCM to the list of watched resources, so the manager will add updates to the cache.