### PR TITLE
Bug 2059716: Ensure release version is set on config sync controller

### DIFF
--- a/cmd/config-sync-controllers/main.go
+++ b/cmd/config-sync-controllers/main.go
@@ -120,6 +120,7 @@ func main() {
 		ClusterOperatorStatusClient: controllers.ClusterOperatorStatusClient{
 			Client:           mgr.GetClient(),
 			Recorder:         mgr.GetEventRecorderFor("cloud-controller-manager-operator-cloud-config-sync-controller"),
+			ReleaseVersion:   controllers.GetReleaseVersion(),
 			ManagedNamespace: *managedNamespace,
 		},
 		Scheme: mgr.GetScheme(),


### PR DESCRIPTION
Follow up to #175, I missed this controller and only added the release version to one of the two controllers in this manager