### PR TITLE
[release-4.9] Bug 2064837: Fix CCCMO metric ports configuration

### DIFF
--- a/cmd/config-sync-controllers/main.go
+++ b/cmd/config-sync-controllers/main.go
@@ -67,12 +67,6 @@ func init() {
 func main() {
 	klog.InitFlags(nil)
 
-	metricsAddr := flag.String(
-		"metrics-bind-address",
-		":8080",
-		"Address for hosting metrics",
-	)
-
 	healthAddr := flag.String(
 		"health-addr",
 		":9440",
@@ -101,7 +95,7 @@ func main() {
 		Namespace:               *managedNamespace,
 		Scheme:                  scheme,
 		SyncPeriod:              &syncPeriod,
-		MetricsBindAddress:      *metricsAddr,
+		MetricsBindAddress:      "0", // we do not expose any metric at this point
 		HealthProbeBindAddress:  *healthAddr,
 		LeaderElectionNamespace: leaderElectionConfig.ResourceNamespace,
 		LeaderElection:          leaderElectionConfig.LeaderElect,

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -44,7 +44,16 @@ spec:
           --leader-elect-renew-deadline=107s \
           --leader-elect-retry-period=26s \
           --leader-elect-resource-namespace=openshift-cloud-controller-manager-operator \
-          "--images-json=/etc/cloud-controller-manager-config/images.json"
+          "--images-json=/etc/cloud-controller-manager-config/images.json" \
+          --metrics-bind-address=:9258 \
+          --health-addr=127.0.0.1:9259
+        ports:
+        - containerPort: 9258
+          name: metrics
+          protocol: TCP
+        - containerPort: 9259
+          name: healthz
+          protocol: TCP
         env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
@@ -77,13 +86,9 @@ spec:
             --leader-elect-renew-deadline=107s \
             --leader-elect-retry-period=26s \
             --leader-elect-resource-namespace=openshift-cloud-controller-manager-operator \
-            --metrics-bind-address=:9258 \
-            --health-addr=127.0.0.1:9259
+            --health-addr=127.0.0.1:9260
         ports:
-        - containerPort: 9258
-          name: metrics
-          protocol: TCP
-        - containerPort: 9259
+        - containerPort: 9260
           name: healthz
           protocol: TCP
         resources:


### PR DESCRIPTION
Manual cherry pick of #164

deployment misconfiguration causes upgrade issues from 4.8 to 4.9

Disable redundant config-sync-controller metrics server,
change health check port from 9259 to 9260.
Reassign mistakenly exposed ports from config-sync-controller to operator.

(cherry picked from commit 07cc7d760ee3e0e17b41913185394b08d32c99a7)