### PR TITLE
Bug 2074471: Update enabled and use-octavia options in cloud-conf config-map

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
@@ -64,6 +64,15 @@ rules:
   - list
   - watch
 
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - networks
+  verbs:
+  - get
+  - list
+  - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -21,7 +21,7 @@ import (
 
 // cloudConfigTransformer function transforms the source config map using the input infrastructure.config.openshift.io object.
 // only the data and binaryData field of the output ConfigMap will be respected by consumer of the transformer.
-type cloudConfigTransformer func(source string, infra *configv1.Infrastructure) (string, error)
+type cloudConfigTransformer func(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error)
 
 // GetCloudConfigTransformer returns the function that should be used to transform
 // the cloud configuration config map

--- a/pkg/cloud/common/config.go
+++ b/pkg/cloud/common/config.go
@@ -6,6 +6,6 @@ import (
 
 // NoOpTransformer implements the cloudConfigTransformer. It makes no changes
 // to the source configuration and simply returns it as-is.
-func NoOpTransformer(source string, infra *configv1.Infrastructure) (string, error) {
+func NoOpTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error) {
 	return source, nil
 }


### PR DESCRIPTION
Since Neutron-LBaaS has been deprecated in OpenStack since queens
release, we must ensure installations use Octavia by default. Also,
when running one installation with Kuryr SDN the cloud provider
shouldn't handle the Services as Kuryr already does that. This commit
fixes the issues by ensuring that use-octavia is set as True and
enabled is set as False.