### PR TITLE
Bug 2074606: Allow OpenStack CCM to annotate Service objects

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_04_rbac_provider_openstack.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_04_rbac_provider_openstack.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: kube-system
+  name: cloud-controller-manager
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: openstack-cloud-controller-manager
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+- apiGroups:
+  - ""
+  # Required by occm to annotate services
+  resources:
+  - services
+  verbs:
+  - patch
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: openstack-cloud-controller-manager
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  kind: ClusterRole
+  name: openstack-cloud-controller-manager
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  namespace: kube-system
+  name: cloud-controller-manager


### PR DESCRIPTION
cloud-provider-openstack expects to be able to [add an annotation to a LoadBalancer](https://github.com/kubernetes/cloud-provider-openstack/blob/21ce6dd984e5599ba3c411c960acdbcf9b5dbf03/pkg/openstack/loadbalancer.go#L1907) and [loadbalancer reconcile fails attempting to patch](https://github.com/kubernetes/cloud-provider-openstack/blob/21ce6dd984e5599ba3c411c960acdbcf9b5dbf03/pkg/openstack/loadbalancer.go#L1783) if it cannot.

Code in CPO executed by the service-controller runs as `cloud-controller-manager` in the `kube-system` namespace, which is [a dynamically created but hardcoded service account used by occm](https://github.com/kubernetes/cloud-provider-openstack/blob/21ce6dd984e5599ba3c411c960acdbcf9b5dbf03/pkg/openstack/openstack.go#L173).