### PR TITLE
OpenStack: ensure config-map is updated only when needed

### DIFF
--- a/pkg/cloud/openstack/openstack.go
+++ b/pkg/cloud/openstack/openstack.go
@@ -125,12 +125,13 @@ func CloudConfigTransformer(source string, infra *configv1.Infrastructure) (stri
 		}
 	}
 
-	for key, value := range map[string]string{
-		"use-clouds":  "true",
-		"clouds-file": "/etc/openstack/secret/clouds.yaml",
-		"cloud":       "openstack",
+	// Use a slice to preserve keys order
+	for _, o := range []struct{ k, v string }{
+		{"use-clouds", "true"},
+		{"clouds-file", "/etc/openstack/secret/clouds.yaml"},
+		{"cloud", "openstack"},
 	} {
-		_, err = global.NewKey(key, value)
+		_, err = global.NewKey(o.k, o.v)
 		if err != nil {
 			return "", fmt.Errorf("failed to modify the provided configuration: %w", err)
 		}


### PR DESCRIPTION
The managed config-map is often updated even when all the
keys have the correct value, this behaviour is caused
by the fact that the order of the iteration of config-map
keys not preserved when using golang Map, consequently the final
version of the config-map would be considered different
from the previous one, when shouldn't. This commit fixes
the issue by ensuring that the order of the keys is
preserved in the config-map.