### PR TITLE
Bug 2079791: Ensure release version is injected into all controller status clients

### DIFF
--- a/cmd/cluster-cloud-controller-manager-operator/main.go
+++ b/cmd/cluster-cloud-controller-manager-operator/main.go
@@ -56,9 +56,7 @@ var (
 )
 
 const (
-	defaultImagesLocation         = "/etc/cloud-controller-manager-config/images.json"
-	releaseVersionEnvVariableName = "RELEASE_VERSION"
-	unknownVersionValue           = "unknown"
+	defaultImagesLocation = "/etc/cloud-controller-manager-config/images.json"
 )
 
 func init() {
@@ -136,7 +134,7 @@ func main() {
 		ClusterOperatorStatusClient: controllers.ClusterOperatorStatusClient{
 			Client:           mgr.GetClient(),
 			Recorder:         mgr.GetEventRecorderFor("cloud-controller-manager-operator"),
-			ReleaseVersion:   getReleaseVersion(),
+			ReleaseVersion:   controllers.GetReleaseVersion(),
 			ManagedNamespace: *managedNamespace,
 		},
 		Scheme:     mgr.GetScheme(),
@@ -161,13 +159,4 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-}
-
-func getReleaseVersion() string {
-	releaseVersion := os.Getenv(releaseVersionEnvVariableName)
-	if len(releaseVersion) == 0 {
-		releaseVersion = unknownVersionValue
-		klog.Infof("%s environment variable is missing, defaulting to %q", releaseVersionEnvVariableName, unknownVersionValue)
-	}
-	return releaseVersion
 }

--- a/cmd/config-sync-controllers/main.go
+++ b/cmd/config-sync-controllers/main.go
@@ -120,6 +120,7 @@ func main() {
 		ClusterOperatorStatusClient: controllers.ClusterOperatorStatusClient{
 			Client:           mgr.GetClient(),
 			Recorder:         mgr.GetEventRecorderFor("cloud-controller-manager-operator-cloud-config-sync-controller"),
+			ReleaseVersion:   controllers.GetReleaseVersion(),
 			ManagedNamespace: *managedNamespace,
 		},
 		Scheme: mgr.GetScheme(),
@@ -132,6 +133,7 @@ func main() {
 		ClusterOperatorStatusClient: controllers.ClusterOperatorStatusClient{
 			Client:           mgr.GetClient(),
 			Recorder:         mgr.GetEventRecorderFor("cloud-controller-manager-operator-ca-sync-controller"),
+			ReleaseVersion:   controllers.GetReleaseVersion(),
 			ManagedNamespace: *managedNamespace,
 		},
 		Scheme: mgr.GetScheme(),

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -91,6 +91,9 @@ spec:
         - containerPort: 9260
           name: healthz
           protocol: TCP
+        env:
+        - name: RELEASE_VERSION
+          value: "0.0.1-snapshot"
         resources:
           requests:
             cpu: 10m

--- a/pkg/controllers/status.go
+++ b/pkg/controllers/status.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
@@ -29,6 +30,11 @@ const (
 	clusterOperatorName        = "cloud-controller-manager"
 	operatorVersionKey         = "operator"
 	defaultManagementNamespace = "openshift-cloud-controller-manager-operator"
+)
+
+const (
+	releaseVersionEnvVariableName = "RELEASE_VERSION"
+	unknownVersionValue           = "unknown"
 )
 
 type ClusterOperatorStatusClient struct {
@@ -203,4 +209,14 @@ func (r *ClusterOperatorStatusClient) syncStatus(ctx context.Context, co *config
 	}
 
 	return r.Status().Update(ctx, co)
+}
+
+// GetReleaseVersion gets the release version string from the env
+func GetReleaseVersion() string {
+	releaseVersion := os.Getenv(releaseVersionEnvVariableName)
+	if len(releaseVersion) == 0 {
+		releaseVersion = unknownVersionValue
+		klog.Infof("%s environment variable is missing, defaulting to %q", releaseVersionEnvVariableName, unknownVersionValue)
+	}
+	return releaseVersion
 }


### PR DESCRIPTION
Manual cherry-pick of #175 and #176

> We must ensure that the release version environment variable is observed in all controllers else the version reported by the clusteroperator will flap during execution