### PR TITLE
Remove port argument and update enivronment variable name from powervs cloud provider deployment

### DIFF
--- a/pkg/cloud/powervs/assets/deployment.yaml
+++ b/pkg/cloud/powervs/assets/deployment.yaml
@@ -75,7 +75,6 @@ spec:
               source /etc/kubernetes/apiserver-url.env
             fi
             exec /bin/ibm-cloud-controller-manager \
-            --port=0 \
             --bind-address=$(POD_IP_ADDRESS) \
             --use-service-account-credentials=true \
             --configure-cloud-routes=false \

--- a/pkg/cloud/powervs/assets/deployment.yaml
+++ b/pkg/cloud/powervs/assets/deployment.yaml
@@ -63,7 +63,7 @@ spec:
                 fieldPath: status.podIP
           - name: VPCCTL_CLOUD_CONFIG
             value: /etc/ibm/cloud.conf
-          - name: VPCCTL_PUBLIC_ENDPOINT
+          - name: ENABLE_VPC_PUBLIC_ENDPOINT
             value: "true"
         command:
           - /bin/bash


### PR DESCRIPTION
With the latet update to Power VS cloud provider, its no more accepting port as argument

```
Error: unknown flag: --port
```

also there is [change](https://github.com/Karthik-K-N/cloud-provider-powervs/blob/c22143b62aa5c2230c3da784905d2343b4c80319/ibm/ibm_vpc_cloud.go#L36-L35) in environmental variable used to set use public endpoints for VPC