### PR TITLE
Bug 2082687: IBMCloud: Remove CCM port argument

### DIFF
--- a/pkg/cloud/ibm/assets/deployment.yaml
+++ b/pkg/cloud/ibm/assets/deployment.yaml
@@ -75,7 +75,6 @@ spec:
               source /etc/kubernetes/apiserver-url.env
             fi
             exec /bin/ibm-cloud-controller-manager \
-            --port=0 \
             --bind-address=$(POD_IP_ADDRESS) \
             --use-service-account-credentials=true \
             --configure-cloud-routes=false \


### PR DESCRIPTION
For the IBM Cloud CCM deployment, remove the unsupported --port
argument.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2082687