### PR TITLE
Bug 2099499: Backport resourceapply changes for being able to recreate daemonsets/deployments

### DIFF
--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -675,6 +675,7 @@ var _ = Describe("Apply resources should", func() {
 		}
 
 		recorder = record.NewFakeRecorder(32)
+		recorder.IncludeObject = true
 		reconciler = &CloudOperatorReconciler{
 			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
 				Client:   cl,
@@ -709,7 +710,7 @@ var _ = Describe("Apply resources should", func() {
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated).To(BeTrue())
-		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 	})
 
 	It("Expect update when deployment generation have changed", func() {
@@ -730,7 +731,7 @@ var _ = Describe("Apply resources should", func() {
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated).To(BeTrue())
-		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		dep.Spec.Replicas = pointer.Int32Ptr(20)
 
@@ -755,7 +756,7 @@ var _ = Describe("Apply resources should", func() {
 		updated, err := reconciler.applyResources(context.TODO(), objects)
 		Expect(err).Should(HaveOccurred())
 		Expect(updated).To(BeFalse())
-		Eventually(recorder.Events).Should(Receive(ContainSubstring("Update failed")))
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("Create failed")))
 	})
 
 	It("Expect no update when resources are applied twice", func() {
@@ -768,7 +769,7 @@ var _ = Describe("Apply resources should", func() {
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated).To(BeTrue())
-		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		updated, err = reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
@@ -794,7 +795,7 @@ var _ = Describe("Apply resources should", func() {
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated).To(BeTrue())
-		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		// Manually changing the port number
 		ports := []corev1.ContainerPort{
@@ -854,7 +855,7 @@ var _ = Describe("Apply resources should", func() {
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated).To(BeTrue())
-		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		// Manually adding another port
 		newPort := corev1.ContainerPort{
@@ -917,7 +918,7 @@ var _ = Describe("Apply resources should", func() {
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated).To(BeTrue())
-		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		// Manually inserting a new label
 		dep.Labels[labelName] = labelValue
@@ -970,7 +971,7 @@ var _ = Describe("Apply resources should", func() {
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated).To(BeTrue())
-		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
+		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		// Now the deployment has just one label "k8s-app: aws-cloud-controller-manager"
 		// Manually modifying the value

--- a/pkg/controllers/resourceapply/resourceapply_test.go
+++ b/pkg/controllers/resourceapply/resourceapply_test.go
@@ -4,18 +4,86 @@ import (
 	"context"
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
-
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	appsclientv1 "sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
+func setupEnvtest(t *testing.T) (client.Client, func(t *testing.T)) {
+	t.Log("Setup envtest")
+	g := NewWithT(t)
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cfg).NotTo(BeNil())
+
+	cl, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(cl).NotTo(BeNil())
+
+	teardownFunc := func(t *testing.T) {
+		t.Log("Stop envtest")
+		g.Expect(testEnv.Stop()).To(Succeed())
+	}
+	return cl, teardownFunc
+}
+
+func cleanupResources(t *testing.T, g *WithT, ctx context.Context, cl client.Client, listObject client.ObjectList) {
+	g.Expect(cl.List(ctx, listObject)).To(Succeed())
+	deleteResouce := func(g *WithT, obj client.Object) {
+		key := client.ObjectKeyFromObject(obj)
+		obj.SetFinalizers([]string{})
+		g.Expect(cl.Update(ctx, obj)).To(Succeed())
+		err := cl.Delete(ctx, obj)
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Eventually(
+			apierrors.IsNotFound(cl.Get(ctx, key, obj)),
+		).Should(BeTrue(), "Can not cleanup resources")
+	}
+
+	switch typedList := listObject.(type) {
+	case *appsv1.DeploymentList:
+		for _, obj := range typedList.Items {
+			deleteResouce(g, &obj)
+		}
+	case *corev1.ConfigMapList:
+		for _, obj := range typedList.Items {
+			deleteResouce(g, &obj)
+		}
+	case *appsv1.DaemonSetList:
+		for _, obj := range typedList.Items {
+			deleteResouce(g, &obj)
+		}
+	default:
+		t.Fatal("can not cast list type for cleanup")
+	}
+}
+
+func createNamespace(g *WithT, ctx context.Context, cl client.Client) string {
+	ns := &corev1.Namespace{}
+	ns.SetGenerateName("resource-apply-test-")
+	g.Expect(cl.Create(ctx, ns)).To(Succeed())
+	return ns.GetName()
+}
+
 func TestApplyConfigMap(t *testing.T) {
+	cl, tearDownFn := setupEnvtest(t)
+	defer tearDownFn(t)
+	namespace := createNamespace(NewWithT(t), context.TODO(), cl)
+
 	tests := []struct {
 		name     string
 		existing *corev1.ConfigMap
@@ -26,7 +94,7 @@ func TestApplyConfigMap(t *testing.T) {
 		{
 			name: "create",
 			input: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "foo"},
 			},
 
 			expectedModified: true,
@@ -34,10 +102,10 @@ func TestApplyConfigMap(t *testing.T) {
 		{
 			name: "skip on extra label",
 			existing: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 			},
 			input: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "foo"},
 			},
 
 			expectedModified: false,
@@ -45,10 +113,10 @@ func TestApplyConfigMap(t *testing.T) {
 		{
 			name: "update on missing label",
 			existing: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 			},
 			input: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"new": "merge"}},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "foo", Labels: map[string]string{"new": "merge"}},
 			},
 
 			expectedModified: true,
@@ -56,10 +124,10 @@ func TestApplyConfigMap(t *testing.T) {
 		{
 			name: "update on mismatch data",
 			existing: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 			},
 			input: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "foo"},
 				Data: map[string]string{
 					"configmap": "value",
 				},
@@ -70,13 +138,13 @@ func TestApplyConfigMap(t *testing.T) {
 		{
 			name: "update on mismatch binary data",
 			existing: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "foo", Labels: map[string]string{"extra": "leave-alone"}},
 				Data: map[string]string{
 					"configmap": "value",
 				},
 			},
 			input: &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "one-ns", Name: "foo"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "foo"},
 				Data: map[string]string{
 					"configmap": "value",
 				},
@@ -91,25 +159,25 @@ func TestApplyConfigMap(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := fakeclient.NewClientBuilder().Build()
+			g := NewWithT(t)
+			ctx := context.TODO()
+			defer cleanupResources(t, g, ctx, cl, &corev1.ConfigMapList{})
+
 			if test.existing != nil {
-				err := client.Create(context.TODO(), test.existing)
-				if err != nil {
-					t.Fatal(err)
-				}
+				g.Expect(cl.Create(ctx, test.existing)).To(Succeed())
 			}
-			actualModified, err := applyConfigMap(context.TODO(), client, record.NewFakeRecorder(1000), test.input)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if test.expectedModified != actualModified {
-				t.Errorf("expected %v, got %v", test.expectedModified, actualModified)
-			}
+			actualModified, err := applyConfigMap(ctx, cl, record.NewFakeRecorder(1000), test.input)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(test.expectedModified).To(BeEquivalentTo(actualModified), "Resource was modified")
 		})
 	}
 }
 
 func TestApplyDeployment(t *testing.T) {
+	cl, tearDownFn := setupEnvtest(t)
+	defer tearDownFn(t)
+	namespace := createNamespace(NewWithT(t), context.TODO(), cl)
+
 	tests := []struct {
 		name              string
 		desiredDeployment *appsv1.Deployment
@@ -121,45 +189,29 @@ func TestApplyDeployment(t *testing.T) {
 	}{
 		{
 			name:               "the deployment is created because it doesn't exist",
-			desiredDeployment:  workloadDeployment(),
-			expectedDeployment: workloadDeploymentWithDefaultSpecHash(),
+			desiredDeployment:  workloadDeployment(namespace),
+			expectedDeployment: workloadDeploymentWithDefaultSpecHash(namespace),
 			expectedUpdate:     true,
 		},
 
 		{
 			name:               "the deployment already exists and it's up to date",
-			desiredDeployment:  workloadDeployment(),
-			actualDeployment:   workloadDeploymentWithDefaultSpecHash(),
-			expectedDeployment: workloadDeploymentWithDefaultSpecHash(),
-		},
-
-		{
-			name:              "the actual deployment was modified by a user and must be updated",
-			desiredDeployment: workloadDeployment(),
-			actualDeployment: func() *appsv1.Deployment {
-				w := workloadDeploymentWithDefaultSpecHash()
-				w.Generation = 2
-				return w
-			}(),
-			expectedDeployment: func() *appsv1.Deployment {
-				w := workloadDeploymentWithDefaultSpecHash()
-				w.Generation = 3
-				return w
-			}(),
-			expectedUpdate: true,
+			desiredDeployment:  workloadDeployment(namespace),
+			actualDeployment:   workloadDeploymentWithDefaultSpecHash(namespace),
+			expectedDeployment: workloadDeploymentWithDefaultSpecHash(namespace),
 		},
 
 		{
 			name: "the deployment is updated due to a change in the spec",
 			desiredDeployment: func() *appsv1.Deployment {
-				w := workloadDeployment()
+				w := workloadDeployment(namespace)
 				w.Spec.Template.Finalizers = []string{"newFinalizer"}
 				return w
 			}(),
-			actualDeployment: workloadDeploymentWithDefaultSpecHash(),
+			actualDeployment: workloadDeploymentWithDefaultSpecHash(namespace),
 			expectedDeployment: func() *appsv1.Deployment {
-				w := workloadDeployment()
-				w.Annotations["operator.openshift.io/spec-hash"] = "5322a9feed3671ec5e7bc72c86c9b7e2f628b00e9c7c8c4c93a48ee63e8db47a"
+				w := workloadDeployment(namespace)
+				w.Annotations["operator.openshift.io/spec-hash"] = "3595383676891d94b068a1b3cfedc7e1e77f86f49ae53a30757b4f7f5cd4b36a"
 				w.Spec.Template.Finalizers = []string{"newFinalizer"}
 				return w
 			}(),
@@ -169,13 +221,13 @@ func TestApplyDeployment(t *testing.T) {
 		{
 			name: "the deployment is updated due to a change in Labels field",
 			desiredDeployment: func() *appsv1.Deployment {
-				w := workloadDeployment()
+				w := workloadDeployment(namespace)
 				w.Labels["newLabel"] = "newValue"
 				return w
 			}(),
-			actualDeployment: workloadDeploymentWithDefaultSpecHash(),
+			actualDeployment: workloadDeploymentWithDefaultSpecHash(namespace),
 			expectedDeployment: func() *appsv1.Deployment {
-				w := workloadDeploymentWithDefaultSpecHash()
+				w := workloadDeploymentWithDefaultSpecHash(namespace)
 				w.Labels["newLabel"] = "newValue"
 				return w
 			}(),
@@ -185,13 +237,13 @@ func TestApplyDeployment(t *testing.T) {
 		{
 			name: "the deployment is updated due to a change in Annotations field",
 			desiredDeployment: func() *appsv1.Deployment {
-				w := workloadDeployment()
+				w := workloadDeployment(namespace)
 				w.Annotations["newAnnotation"] = "newValue"
 				return w
 			}(),
-			actualDeployment: workloadDeploymentWithDefaultSpecHash(),
+			actualDeployment: workloadDeploymentWithDefaultSpecHash(namespace),
 			expectedDeployment: func() *appsv1.Deployment {
-				w := workloadDeploymentWithDefaultSpecHash()
+				w := workloadDeploymentWithDefaultSpecHash(namespace)
 				w.Annotations["newAnnotation"] = "newValue"
 				return w
 			}(),
@@ -200,43 +252,163 @@ func TestApplyDeployment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			eventRecorder := record.NewFakeRecorder(1000)
-			client := fakeclient.NewClientBuilder().Build()
+			ctx := context.TODO()
+			defer cleanupResources(t, g, ctx, cl, &appsv1.DeploymentList{})
+
 			if tt.actualDeployment != nil {
-				err := client.Create(context.TODO(), tt.actualDeployment)
-				if err != nil {
-					t.Fatal(err)
-				}
+				g.Expect(cl.Create(ctx, tt.actualDeployment)).To(Succeed())
 			}
 
-			updated, err := applyDeployment(context.TODO(), client, eventRecorder, tt.desiredDeployment)
-			if tt.expectError && err == nil {
-				t.Fatal("expected to get an error")
+			updated, err := applyDeployment(ctx, cl, eventRecorder, tt.desiredDeployment)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred(), "expected error")
 			}
-			if !tt.expectError && err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			if !tt.expectError {
+				g.Expect(err).NotTo(HaveOccurred(), "expected no error")
 			}
-			if tt.expectedUpdate && !updated {
-				t.Fatal("expected ApplyDeployment to report updated=true")
+			if tt.expectedUpdate {
+				g.Expect(updated).To(BeTrue(), "expect deployment to be updated")
 			}
-			if !tt.expectedUpdate && updated {
-				t.Fatal("expected ApplyDeployment to report updated=false")
+			if !tt.expectedUpdate {
+				g.Expect(updated).To(BeFalse(), "expect deployment not to be updated")
 			}
 
 			updatedDeployment := &appsv1.Deployment{}
-			err = client.Get(context.TODO(), appsclientv1.ObjectKeyFromObject(tt.desiredDeployment), updatedDeployment)
-			if err != nil {
-				t.Fatal(err)
+			deploymentObjectKey := appsclientv1.ObjectKeyFromObject(tt.desiredDeployment)
+			g.Expect(cl.Get(ctx, deploymentObjectKey, updatedDeployment)).To(Succeed())
+
+			if !equality.Semantic.DeepDerivative(tt.expectedDeployment.Spec, updatedDeployment.Spec) {
+				t.Fatalf("Expected deployment: %+v, got %+v", tt.expectedDeployment, updatedDeployment)
+			}
+			g.Expect(tt.expectedDeployment.Annotations[specHashAnnotation]).Should(BeEquivalentTo(updatedDeployment.Annotations[specHashAnnotation]))
+		})
+	}
+
+	updateSelectorTests := []struct {
+		name               string
+		desiredDeployment  *appsv1.Deployment
+		expectedDeployment *appsv1.Deployment
+		actualDeployment   *appsv1.Deployment
+
+		expectError      bool
+		errorMsg         string
+		expectedRecreate bool
+	}{
+		{
+			name:             "the deployment is recreated due to a change in match labels field",
+			actualDeployment: workloadDeploymentWithDefaultSpecHash(namespace),
+
+			desiredDeployment: func() *appsv1.Deployment {
+				w := workloadDeployment(namespace)
+				w.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"bar": "baz",
+					},
+				}
+				w.Spec.Template.Labels = map[string]string{"bar": "baz"}
+				return w
+			}(),
+			expectedDeployment: func() *appsv1.Deployment {
+				w := workloadDeploymentWithDefaultSpecHash(namespace)
+				w.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"bar": "baz",
+					},
+				}
+				w.Spec.Template.Labels = map[string]string{"bar": "baz"}
+				w.Annotations[specHashAnnotation] = "5e54f6f565b4d03edbdf5e129492b54cee18bb3ed84dcd84be02d5dd86e280fa"
+				return w
+			}(),
+			expectedRecreate: true,
+		},
+
+		{
+			name:             "resourceapply should report an error in case if resource is malformed",
+			actualDeployment: workloadDeploymentWithDefaultSpecHash(namespace),
+
+			desiredDeployment: func() *appsv1.Deployment {
+				w := workloadDeployment(namespace)
+				w.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"bar": "baz",
+					},
+				}
+				w.Spec.Template.Labels = map[string]string{"fiz": "baz"}
+				return w
+			}(),
+			expectedDeployment: workloadDeploymentWithDefaultSpecHash(namespace),
+			errorMsg:           "`selector` does not match template `labels`",
+			expectError:        true,
+		},
+
+		{
+			name: "resourceapply should report an error in case if resource deletion stucked",
+			actualDeployment: func() *appsv1.Deployment {
+				d := workloadDeploymentWithDefaultSpecHash(namespace)
+				d.Finalizers = []string{"foo.bar/baz"}
+				return d
+			}(),
+
+			desiredDeployment: func() *appsv1.Deployment {
+				w := workloadDeployment(namespace)
+				w.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"bar": "baz",
+					},
+				}
+				w.Spec.Template.Labels = map[string]string{"bar": "baz"}
+				return w
+			}(),
+			expectedDeployment: workloadDeploymentWithDefaultSpecHash(namespace),
+			errorMsg:           "object is being deleted: deployments.apps \"apiserver\" already exists",
+			expectError:        true,
+		},
+	}
+	for _, tt := range updateSelectorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			eventRecorder := record.NewFakeRecorder(1000)
+			ctx := context.TODO()
+			defer cleanupResources(t, g, ctx, cl, &appsv1.DeploymentList{})
+
+			g.Expect(cl.Create(ctx, tt.actualDeployment)).To(Succeed())
+			g.Expect(tt.actualDeployment.UID).NotTo(BeNil())
+
+			_, err := applyDeployment(ctx, cl, eventRecorder, tt.desiredDeployment)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred(), "expected error")
+				g.Expect(tt.errorMsg).ToNot(BeEmpty())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errorMsg))
+			}
+			if !tt.expectError {
+				g.Expect(err).NotTo(HaveOccurred(), "expected no error")
+			}
+
+			updatedDeployment := &appsv1.Deployment{}
+			deploymentObjectKey := appsclientv1.ObjectKeyFromObject(tt.desiredDeployment)
+			g.Expect(cl.Get(ctx, deploymentObjectKey, updatedDeployment)).To(Succeed())
+			if tt.expectedRecreate {
+				g.Expect(tt.actualDeployment.UID).ShouldNot(BeEquivalentTo(updatedDeployment.UID))
+			}
+			if !tt.expectedRecreate {
+				g.Expect(tt.actualDeployment.UID).Should(BeEquivalentTo(updatedDeployment.UID))
 			}
 
 			if !equality.Semantic.DeepDerivative(tt.expectedDeployment.Spec, updatedDeployment.Spec) {
 				t.Fatalf("Expected deployment: %+v, got %+v", tt.expectedDeployment, updatedDeployment)
 			}
+			g.Expect(tt.expectedDeployment.Annotations[specHashAnnotation]).To(BeEquivalentTo(updatedDeployment.Annotations[specHashAnnotation]))
+
+			deployments := &appsv1.DeploymentList{}
+			g.Expect(cl.List(ctx, deployments)).To(Succeed())
+			g.Expect(len(deployments.Items)).To(BeEquivalentTo(1))
 		})
 	}
 }
 
-func workloadDeployment() *appsv1.Deployment {
+func workloadDeployment(namespace string) *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Deployment",
@@ -244,7 +416,7 @@ func workloadDeployment() *appsv1.Deployment {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "apiserver",
-			Namespace: "openshift-apiserver",
+			Namespace: namespace,
 			Labels:    map[string]string{},
 			Annotations: map[string]string{
 				generationAnnotation: "1",
@@ -253,9 +425,16 @@ func workloadDeployment() *appsv1.Deployment {
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: pointer.Int32Ptr(3),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "bar",
+				},
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{},
+					Labels: map[string]string{
+						"foo": "bar",
+					},
 					Annotations: map[string]string{},
 				},
 				Spec: corev1.PodSpec{
@@ -271,13 +450,17 @@ func workloadDeployment() *appsv1.Deployment {
 	}
 }
 
-func workloadDeploymentWithDefaultSpecHash() *appsv1.Deployment {
-	w := workloadDeployment()
-	w.Annotations[specHashAnnotation] = "9ed89f9298716b3cde992326224f46d46e84042c41f9ff5820e7811f318be99e"
+func workloadDeploymentWithDefaultSpecHash(namespace string) *appsv1.Deployment {
+	w := workloadDeployment(namespace)
+	w.Annotations[specHashAnnotation] = "259870a8d6f8fca4ded383158594ac91935b0225acabe8e16670b6f6a395f68d"
 	return w
 }
 
 func TestApplyDaemonSet(t *testing.T) {
+	cl, tearDownFn := setupEnvtest(t)
+	defer tearDownFn(t)
+	namespace := createNamespace(NewWithT(t), context.TODO(), cl)
+
 	tests := []struct {
 		name             string
 		desiredDaemonSet *appsv1.DaemonSet
@@ -289,45 +472,29 @@ func TestApplyDaemonSet(t *testing.T) {
 	}{
 		{
 			name:              "the daemonset is created because it doesn't exist",
-			desiredDaemonSet:  workloadDaemonSet(),
-			expectedDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
+			desiredDaemonSet:  workloadDaemonSet(namespace),
+			expectedDaemonSet: workloadDaemonSetWithDefaultSpecHash(namespace),
 			expectedUpdate:    true,
 		},
 
 		{
 			name:              "the daemonset already exists and it's up to date",
-			desiredDaemonSet:  workloadDaemonSet(),
-			actualDaemonSet:   workloadDaemonSetWithDefaultSpecHash(),
-			expectedDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
-		},
-
-		{
-			name:             "the actual daemonset was modified by a user and must be updated",
-			desiredDaemonSet: workloadDaemonSet(),
-			actualDaemonSet: func() *appsv1.DaemonSet {
-				w := workloadDaemonSetWithDefaultSpecHash()
-				w.Generation = 2
-				return w
-			}(),
-			expectedDaemonSet: func() *appsv1.DaemonSet {
-				w := workloadDaemonSetWithDefaultSpecHash()
-				w.Generation = 3
-				return w
-			}(),
-			expectedUpdate: true,
+			desiredDaemonSet:  workloadDaemonSet(namespace),
+			actualDaemonSet:   workloadDaemonSetWithDefaultSpecHash(namespace),
+			expectedDaemonSet: workloadDaemonSetWithDefaultSpecHash(namespace),
 		},
 
 		{
 			name: "the daemonset is updated due to a change in the spec",
 			desiredDaemonSet: func() *appsv1.DaemonSet {
-				w := workloadDaemonSet()
+				w := workloadDaemonSet(namespace)
 				w.Spec.Template.Finalizers = []string{"newFinalizer"}
 				return w
 			}(),
-			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
+			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(namespace),
 			expectedDaemonSet: func() *appsv1.DaemonSet {
-				w := workloadDaemonSet()
-				w.Annotations["operator.openshift.io/spec-hash"] = "5322a9feed3671ec5e7bc72c86c9b7e2f628b00e9c7c8c4c93a48ee63e8db47a"
+				w := workloadDaemonSet(namespace)
+				w.Annotations["operator.openshift.io/spec-hash"] = "42ed5653bc5ded7dc099b924ede011e43140c675302d1da42a6b645771d242a0"
 				w.Spec.Template.Finalizers = []string{"newFinalizer"}
 				return w
 			}(),
@@ -337,13 +504,13 @@ func TestApplyDaemonSet(t *testing.T) {
 		{
 			name: "the daemonset is updated due to a change in Labels field",
 			desiredDaemonSet: func() *appsv1.DaemonSet {
-				w := workloadDaemonSet()
+				w := workloadDaemonSet(namespace)
 				w.Labels["newLabel"] = "newValue"
 				return w
 			}(),
-			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
+			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(namespace),
 			expectedDaemonSet: func() *appsv1.DaemonSet {
-				w := workloadDaemonSetWithDefaultSpecHash()
+				w := workloadDaemonSetWithDefaultSpecHash(namespace)
 				w.Labels["newLabel"] = "newValue"
 				return w
 			}(),
@@ -353,13 +520,13 @@ func TestApplyDaemonSet(t *testing.T) {
 		{
 			name: "the daemonset is updated due to a change in Annotations field",
 			desiredDaemonSet: func() *appsv1.DaemonSet {
-				w := workloadDaemonSet()
+				w := workloadDaemonSet(namespace)
 				w.Annotations["newAnnotation"] = "newValue"
 				return w
 			}(),
-			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(),
+			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(namespace),
 			expectedDaemonSet: func() *appsv1.DaemonSet {
-				w := workloadDaemonSetWithDefaultSpecHash()
+				w := workloadDaemonSetWithDefaultSpecHash(namespace)
 				w.Annotations["newAnnotation"] = "newValue"
 				return w
 			}(),
@@ -368,43 +535,159 @@ func TestApplyDaemonSet(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
 			eventRecorder := record.NewFakeRecorder(1000)
-			client := fakeclient.NewClientBuilder().Build()
+			ctx := context.TODO()
+			defer cleanupResources(t, g, ctx, cl, &appsv1.DaemonSetList{})
+
 			if tt.actualDaemonSet != nil {
-				err := client.Create(context.TODO(), tt.actualDaemonSet)
-				if err != nil {
-					t.Fatal(err)
-				}
+				g.Expect(cl.Create(ctx, tt.actualDaemonSet)).To(Succeed())
 			}
 
-			updated, err := applyDaemonSet(context.TODO(), client, eventRecorder, tt.desiredDaemonSet)
-			if tt.expectError && err == nil {
-				t.Fatal("expected to get an error")
+			updated, err := applyDaemonSet(ctx, cl, eventRecorder, tt.desiredDaemonSet)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred(), "expected error")
 			}
-			if !tt.expectError && err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			if !tt.expectError {
+				g.Expect(err).NotTo(HaveOccurred(), "expected no error")
 			}
-			if tt.expectedUpdate && !updated {
-				t.Fatal("expected ApplyDaemonSet to report updated=true")
+			if tt.expectedUpdate {
+				g.Expect(updated).To(BeTrue(), "expect deployment to be updated")
 			}
-			if !tt.expectedUpdate && updated {
-				t.Fatal("expected ApplyDaemonSet to report updated=false")
+			if !tt.expectedUpdate {
+				g.Expect(updated).To(BeFalse(), "expect deployment not to be updated")
 			}
 
 			updatedDaemonSet := &appsv1.DaemonSet{}
-			err = client.Get(context.TODO(), appsclientv1.ObjectKeyFromObject(tt.desiredDaemonSet), updatedDaemonSet)
-			if err != nil {
-				t.Fatal(err)
-			}
+			g.Expect(cl.Get(ctx, appsclientv1.ObjectKeyFromObject(tt.desiredDaemonSet), updatedDaemonSet)).To(Succeed())
 
 			if !equality.Semantic.DeepDerivative(tt.expectedDaemonSet.Spec, updatedDaemonSet.Spec) {
 				t.Fatalf("Expected DaemonSet: %+v, got %+v", tt.expectedDaemonSet, updatedDaemonSet)
 			}
+			g.Expect(tt.expectedDaemonSet.Annotations[specHashAnnotation]).Should(BeEquivalentTo(updatedDaemonSet.Annotations[specHashAnnotation]))
+		})
+	}
+
+	updateSelectorTests := []struct {
+		name              string
+		actualDaemonSet   *appsv1.DaemonSet
+		desiredDaemonSet  *appsv1.DaemonSet
+		expectedDaemonSet *appsv1.DaemonSet
+
+		errorMsg         string
+		expectError      bool
+		expectedRecreate bool
+	}{
+		{
+			name:            "the daemonset is recreated due to a change in match labels field",
+			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(namespace),
+			desiredDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSet(namespace)
+				w.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"bar": "baz",
+					},
+				}
+				w.Spec.Template.Labels = map[string]string{"bar": "baz"}
+				return w
+			}(),
+			expectedDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSet(namespace)
+				w.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"bar": "baz",
+					},
+				}
+				w.Spec.Template.Labels = map[string]string{"bar": "baz"}
+				w.Annotations[specHashAnnotation] = "ba95dff6a88cc11a6cd80aa8a8d7a5e88793809ad27f9f8c5b7b66c39ce13ee4"
+				return w
+			}(),
+			expectedRecreate: true,
+		},
+
+		{
+			name:            "resourceapply should report an error in case if resource is malformed",
+			actualDaemonSet: workloadDaemonSetWithDefaultSpecHash(namespace),
+			desiredDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSet(namespace)
+				w.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"bar": "baz",
+					},
+				}
+				w.Spec.Template.Labels = map[string]string{"fiz": "baz"}
+				return w
+			}(),
+			expectedDaemonSet: workloadDaemonSetWithDefaultSpecHash(namespace),
+			errorMsg:          "`selector` does not match template `labels`",
+			expectError:       true,
+		},
+
+		{
+			name: "resourceapply should report an error in case if resource deletion stucked",
+			actualDaemonSet: func() *appsv1.DaemonSet {
+				ds := workloadDaemonSetWithDefaultSpecHash(namespace)
+				ds.Finalizers = []string{"foo.bar/baz"}
+				return ds
+			}(),
+			desiredDaemonSet: func() *appsv1.DaemonSet {
+				w := workloadDaemonSet(namespace)
+				w.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"bar": "baz",
+					},
+				}
+				w.Spec.Template.Labels = map[string]string{"bar": "baz"}
+				return w
+			}(),
+			expectedDaemonSet: workloadDaemonSetWithDefaultSpecHash(namespace),
+			errorMsg:          "object is being deleted: daemonsets.apps \"apiserver\" already exists",
+			expectError:       true,
+		},
+	}
+	for _, tt := range updateSelectorTests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewWithT(t)
+			eventRecorder := record.NewFakeRecorder(1000)
+			ctx := context.TODO()
+			defer cleanupResources(t, g, ctx, cl, &appsv1.DaemonSetList{})
+
+			g.Expect(cl.Create(ctx, tt.actualDaemonSet)).To(Succeed())
+			g.Expect(tt.actualDaemonSet.UID).NotTo(BeNil())
+
+			_, err := applyDaemonSet(ctx, cl, eventRecorder, tt.desiredDaemonSet)
+			if tt.expectError {
+				g.Expect(err).To(HaveOccurred(), "expected error")
+				g.Expect(tt.errorMsg).NotTo(BeEmpty())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errorMsg))
+			}
+			if !tt.expectError {
+				g.Expect(err).NotTo(HaveOccurred(), "expected no error")
+			}
+
+			updatedDaemonSet := &appsv1.DaemonSet{}
+			deploymentObjectKey := appsclientv1.ObjectKeyFromObject(tt.desiredDaemonSet)
+			g.Expect(cl.Get(ctx, deploymentObjectKey, updatedDaemonSet)).To(Succeed())
+			if tt.expectedRecreate {
+				g.Expect(tt.actualDaemonSet.UID).ShouldNot(BeEquivalentTo(updatedDaemonSet.UID))
+			}
+			if !tt.expectedRecreate {
+				g.Expect(tt.actualDaemonSet.UID).Should(BeEquivalentTo(updatedDaemonSet.UID))
+			}
+
+			if !equality.Semantic.DeepDerivative(tt.expectedDaemonSet.Spec, updatedDaemonSet.Spec) {
+				t.Fatalf("Expected deployment: %+v, got %+v", tt.expectedDaemonSet, updatedDaemonSet)
+			}
+			g.Expect(tt.expectedDaemonSet.Annotations[specHashAnnotation]).To(BeEquivalentTo(updatedDaemonSet.Annotations[specHashAnnotation]))
+
+			dss := &appsv1.DaemonSetList{}
+			g.Expect(cl.List(ctx, dss)).To(Succeed())
+			g.Expect(len(dss.Items)).To(BeEquivalentTo(1))
 		})
 	}
 }
 
-func workloadDaemonSet() *appsv1.DaemonSet {
+func workloadDaemonSet(namespace string) *appsv1.DaemonSet {
 	return &appsv1.DaemonSet{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSet",
@@ -412,7 +695,7 @@ func workloadDaemonSet() *appsv1.DaemonSet {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "apiserver",
-			Namespace: "openshift-apiserver",
+			Namespace: namespace,
 			Labels:    map[string]string{},
 			Annotations: map[string]string{
 				generationAnnotation: "1",
@@ -420,9 +703,14 @@ func workloadDaemonSet() *appsv1.DaemonSet {
 			Generation: 1,
 		},
 		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "bar",
+				},
+			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      map[string]string{},
+					Labels:      map[string]string{"foo": "bar"},
 					Annotations: map[string]string{},
 				},
 				Spec: corev1.PodSpec{
@@ -438,8 +726,8 @@ func workloadDaemonSet() *appsv1.DaemonSet {
 	}
 }
 
-func workloadDaemonSetWithDefaultSpecHash() *appsv1.DaemonSet {
-	w := workloadDaemonSet()
-	w.Annotations[specHashAnnotation] = "ebe199e4e68c8ba52c7723e988895cde2ea804e8d0691d130e689f5168721bd1"
+func workloadDaemonSetWithDefaultSpecHash(namespace string) *appsv1.DaemonSet {
+	w := workloadDaemonSet(namespace)
+	w.Annotations[specHashAnnotation] = "eaeff6ac704fb141d5085803b5b3cc12067ef98c9f2ba8c1052df81faa53299c"
 	return w
 }


### PR DESCRIPTION
Manually cherry-picked resourceapply related changes from
https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/174

Several commits from this patchset was cherry-picked and then squashed together.

Such changes introduces recreation logic for daemonsets/deployments in case if
selectors was changed. Also, this contains respective tests changes.

Commits which was using for prepare this patch:

e1f47b7cbc1d1e908dcf62e90698a474eb40b58d
1bf44f1801d1f33338e7f165b7029726fdfdefdc
d4b6c3fc13d897d7c5226434faeb80784a84ce6a
5b17fa28080d2c43a91de630dc3d1b6ae9625880
a4963609a29c2587ba05ae2b4e8c04b193f71267
9429f586f430d0c0a818798f15fcb224e61599a7
748843291e06cb7506935fda5038b227fac85b73