### PR TITLE
CCM namespace should be labelled as privileged

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_00_namespace.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_00_namespace.yaml
@@ -25,4 +25,7 @@ metadata:
   labels:
     openshift.io/run-level: "0"
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: openshift-cloud-controller-manager


### PR DESCRIPTION
All techpreview jobs are currently failing because of the new pod security admission policy checks. This should resolve the issue for now
```
ns/openshift-cloud-controller-manager replicaset/gcp-cloud-controller-manager-79c85fb79b - reason/FailedCreate (combined from similar events): Error creating: pods "gcp-cloud-controller-manager-79c85fb79b-kln2f" is forbidden: violates PodSecurity "restricted:latest": host namespaces (hostNetwork=true), hostPort (container "cloud-controller-manager" uses hostPort 10258), allowPrivilegeEscalation != false (container "cloud-controller-manager" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "cloud-controller-manager" must set securityContext.capabilities.drop=["ALL"]), restricted volume types (volume "host-etc-kube" uses restricted volume type "hostPath"), runAsNonRoot != true (pod or container "cloud-controller-manager" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "cloud-controller-manager" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")}
```