### PR TITLE
OCPBUGS-4074: Try to limit groups for the REST mapper discovery

### DIFF
--- a/cmd/cluster-cloud-controller-manager-operator/main.go
+++ b/cmd/cluster-cloud-controller-manager-operator/main.go
@@ -41,6 +41,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/controllers"
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/restmapper"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/util"
 	// +kubebuilder:scaffold:imports
 )
@@ -112,11 +113,17 @@ func main() {
 
 	syncPeriod := 10 * time.Minute
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Namespace:               *managedNamespace,
-		Scheme:                  scheme,
-		SyncPeriod:              &syncPeriod,
-		MetricsBindAddress:      *metricsAddr,
-		Port:                    9443,
+		Namespace:          *managedNamespace,
+		Scheme:             scheme,
+		SyncPeriod:         &syncPeriod,
+		MetricsBindAddress: *metricsAddr,
+		Port:               9443,
+		MapperProvider: restmapper.NewPartialRestMapperProvider(
+			restmapper.Or(
+				restmapper.KubernetesCoreGroup, restmapper.KubernetesAppsGroup, restmapper.KubernetesPolicyGroup,
+				restmapper.OpenshiftOperatorGroup, restmapper.OpenshiftConfigGroup,
+			),
+		),
 		HealthProbeBindAddress:  *healthAddr,
 		LeaderElectionNamespace: leaderElectionConfig.ResourceNamespace,
 		LeaderElection:          leaderElectionConfig.LeaderElect,

--- a/pkg/restmapper/predicates.go
+++ b/pkg/restmapper/predicates.go
@@ -1,0 +1,54 @@
+package restmapper
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GroupFilterPredicate filters group during discovery process
+type GroupFilterPredicate func(*metav1.APIGroup) bool
+
+// AllGroups predicate which permits all groups
+func AllGroups(*metav1.APIGroup) bool {
+	return true
+}
+
+// OpenshiftConfigGroup checks if APIGroup is openshift-specific "config.openshift.io"
+func OpenshiftConfigGroup(group *metav1.APIGroup) bool {
+	return group.Name == "config.openshift.io"
+}
+
+// OpenshiftOperatorGroup checks if APIGroup is openshift-specific "operator.openshift.io"
+func OpenshiftOperatorGroup(group *metav1.APIGroup) bool {
+	return group.Name == "operator.openshift.io"
+}
+
+// KubernetesCoreGroup checks if APIGroup is the Kubernetes' "core" ("legacy") group
+// ConfigMaps, Secrets, and other Kube native resources sit here.
+// ref: https://kubernetes.io/docs/reference/using-api/#api-groups
+func KubernetesCoreGroup(group *metav1.APIGroup) bool {
+	return group.Name == ""
+}
+
+// KubernetesAppsGroup checks if APIGroup is the Kubernetes' "apps" group
+// Deployment and Daemonset resources are sitting here.
+func KubernetesAppsGroup(group *metav1.APIGroup) bool {
+	return group.Name == "apps"
+}
+
+// KubernetesPolicyGroup checks if APIGroup is the Kubernetes' "apps" group
+// PodDisruptionBudget is sitting here.
+func KubernetesPolicyGroup(group *metav1.APIGroup) bool {
+	return group.Name == "policy"
+}
+
+// Or combines passed predicate functions in a way to implement logical OR between them.
+func Or(predicates ...GroupFilterPredicate) GroupFilterPredicate {
+	return func(g *metav1.APIGroup) bool {
+		for _, p := range predicates {
+			if p(g) {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/pkg/restmapper/restmapper.go
+++ b/pkg/restmapper/restmapper.go
@@ -1,0 +1,153 @@
+package restmapper
+
+import (
+	"sync"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type RESTMapperProvider func(c *rest.Config) (meta.RESTMapper, error)
+
+// NewPartialRestMapperProvider returns configured 'partial' rest mapper provider intended to be used with controller-runtime manager.
+// Takes GroupFilterPredicate as an argument for filtering out APIGroups during discovery procedure.
+func NewPartialRestMapperProvider(groupFilterPredicate GroupFilterPredicate) RESTMapperProvider {
+	partialRESTMapperProvider := func(c *rest.Config) (meta.RESTMapper, error) {
+		drm, err := apiutil.NewDynamicRESTMapper(c,
+			apiutil.WithLazyDiscovery,
+			apiutil.WithCustomMapper(
+				func() (meta.RESTMapper, error) {
+					dc, err := discovery.NewDiscoveryClientForConfig(c)
+					if err != nil {
+						return nil, err
+					}
+
+					groupResources, err := getFilteredAPIGroupResources(dc, groupFilterPredicate)
+					if err != nil {
+						return nil, err
+					}
+
+					return restmapper.NewDiscoveryRESTMapper(groupResources), nil
+				},
+			),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		return drm, nil
+	}
+	return partialRESTMapperProvider
+}
+
+// fetchGroupVersionResources uses the discovery client to fetch the resources for the specified groups in parallel.
+// Mainly replicates the same named function from the client-go internals aside from the changed `apiGroups` argument type (uses slice instead of APIGroupList).
+// ref: https://github.com/kubernetes/kubernetes/blob/a84d877310ba5cf9237c8e8e3218229c202d3a1e/staging/src/k8s.io/client-go/discovery/discovery_client.go#L506
+func fetchGroupVersionResources(d discovery.DiscoveryInterface, apiGroups []*metav1.APIGroup) (map[schema.GroupVersion]*metav1.APIResourceList, map[schema.GroupVersion]error) {
+	groupVersionResources := make(map[schema.GroupVersion]*metav1.APIResourceList)
+	failedGroups := make(map[schema.GroupVersion]error)
+
+	wg := &sync.WaitGroup{}
+	resultLock := &sync.Mutex{}
+	for _, apiGroup := range apiGroups {
+		for _, version := range apiGroup.Versions {
+			groupVersion := schema.GroupVersion{Group: apiGroup.Name, Version: version.Version}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer utilruntime.HandleCrash()
+
+				apiResourceList, err := d.ServerResourcesForGroupVersion(groupVersion.String())
+
+				// lock to record results
+				resultLock.Lock()
+				defer resultLock.Unlock()
+
+				if err != nil {
+					// TODO: maybe restrict this to NotFound errors
+					failedGroups[groupVersion] = err
+				}
+				if apiResourceList != nil {
+					// even in case of error, some fallback might have been returned
+					groupVersionResources[groupVersion] = apiResourceList
+				}
+			}()
+		}
+	}
+	wg.Wait()
+
+	return groupVersionResources, failedGroups
+}
+
+// filteredServerGroupsAndResources returns the supported resources for groups filtered by passed predicate and versions.
+// Mainly replicate ServerGroupsAndResources function from the client-go. The difference is that this function takes
+// a function of the GroupFilterPredicate type as an argument for filtering out unwanted groups.
+// ref: https://github.com/kubernetes/kubernetes/blob/a84d877310ba5cf9237c8e8e3218229c202d3a1e/staging/src/k8s.io/client-go/discovery/discovery_client.go#L383
+func filteredServerGroupsAndResources(d discovery.DiscoveryInterface, groupFilterPredicate GroupFilterPredicate) ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	sgs, err := d.ServerGroups()
+	if sgs == nil {
+		return nil, nil, err
+	}
+	resultGroups := []*metav1.APIGroup{}
+	for i := range sgs.Groups {
+		if groupFilterPredicate(&sgs.Groups[i]) {
+			resultGroups = append(resultGroups, &sgs.Groups[i])
+		}
+	}
+
+	groupVersionResources, failedGroups := fetchGroupVersionResources(d, resultGroups)
+
+	// order results by group/version discovery order
+	result := []*metav1.APIResourceList{}
+	for _, apiGroup := range resultGroups {
+		for _, version := range apiGroup.Versions {
+			gv := schema.GroupVersion{Group: apiGroup.Name, Version: version.Version}
+			if resources, ok := groupVersionResources[gv]; ok {
+				result = append(result, resources)
+			}
+		}
+	}
+
+	if len(failedGroups) == 0 {
+		return resultGroups, result, nil
+	}
+
+	return resultGroups, result, &discovery.ErrGroupDiscoveryFailed{Groups: failedGroups}
+}
+
+// getFilteredAPIGroupResources uses the provided discovery client to gather
+// discovery information and populate a slice of APIGroupResources.
+func getFilteredAPIGroupResources(cl discovery.DiscoveryInterface, groupFilterPredicate GroupFilterPredicate) ([]*restmapper.APIGroupResources, error) {
+	gs, rs, err := filteredServerGroupsAndResources(cl, groupFilterPredicate)
+	if rs == nil || gs == nil {
+		return nil, err
+		// TODO track the errors and update callers to handle partial errors.
+	}
+	rsm := map[string]*metav1.APIResourceList{}
+	for _, r := range rs {
+		rsm[r.GroupVersion] = r
+	}
+
+	var result []*restmapper.APIGroupResources
+	for _, group := range gs {
+		groupResources := &restmapper.APIGroupResources{
+			Group:              *group,
+			VersionedResources: make(map[string][]metav1.APIResource),
+		}
+		for _, version := range group.Versions {
+			resources, ok := rsm[version.GroupVersion]
+			if !ok {
+				continue
+			}
+			groupResources.VersionedResources[version.Version] = resources.APIResources
+		}
+		result = append(result, groupResources)
+	}
+	return result, nil
+}

--- a/pkg/restmapper/restmapper_test.go
+++ b/pkg/restmapper/restmapper_test.go
@@ -1,0 +1,83 @@
+package restmapper
+
+import (
+	"testing"
+
+	gmg "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func setupEnvtest(t *testing.T) (*rest.Config, func(t *testing.T)) {
+	t.Log("Setup envtest")
+	g := gmg.NewWithT(t)
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	g.Expect(err).NotTo(gmg.HaveOccurred())
+	g.Expect(cfg).NotTo(gmg.BeNil())
+
+	teardownFunc := func(t *testing.T) {
+		t.Log("Stop envtest")
+		g.Expect(testEnv.Stop()).To(gmg.Succeed())
+	}
+	return cfg, teardownFunc
+}
+
+func TestPartialRestMapperProvider(t *testing.T) {
+	restCfg, tearDownFn := setupEnvtest(t)
+	defer tearDownFn(t)
+
+	t.Run("getFilteredAPIGroupResources should return APIGroupResources based on passed predicates", func(t *testing.T) {
+		g := gmg.NewWithT(t)
+
+		discoveryClient, err := discovery.NewDiscoveryClientForConfig(restCfg)
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+
+		// Get GroupResources for all groups
+		apiGroupResources, err := getFilteredAPIGroupResources(discoveryClient, AllGroups)
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+		g.Expect(len(apiGroupResources)).Should(gmg.BeNumerically(">", 0))
+		// One of a built-in k8s api groups
+		g.Expect(apiGroupResources).Should(gmg.ContainElement(gmg.HaveField("Group.Name", "authorization.k8s.io")))
+
+		// Get GroupResources for kubernetes core and kubernetes apps groups
+		appsAndCoreGroupsPredicate := Or(KubernetesCoreGroup, KubernetesAppsGroup)
+		filteredApiGroupResources, err := getFilteredAPIGroupResources(discoveryClient, appsAndCoreGroupsPredicate)
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+		g.Expect(filteredApiGroupResources).Should(gmg.HaveLen(2))
+		group0, group1 := filteredApiGroupResources[0], filteredApiGroupResources[1]
+		g.Expect(group1).ShouldNot(gmg.BeEquivalentTo(group0))
+		g.Expect(filteredApiGroupResources).Should(gmg.ContainElement(gmg.HaveField("Group.Name", "")))
+		g.Expect(filteredApiGroupResources).Should(gmg.ContainElement(gmg.HaveField("Group.Name", "apps")))
+		g.Expect(filteredApiGroupResources).ShouldNot(gmg.ContainElement(gmg.HaveField("Group.Name", "authorization.k8s.io")))
+	})
+
+	t.Run("NewPartialRestMapperProvider should return different RESTMapperProviders based on passed predicates", func(t *testing.T) {
+		g := gmg.NewWithT(t)
+
+		// Create two different REST mappers with different passed group filter predicates
+		allGroupsRestMapperProvider := NewPartialRestMapperProvider(AllGroups)
+		allGroupsRestMapper, err := allGroupsRestMapperProvider(restCfg)
+		g.Expect(err).To(gmg.Succeed())
+
+		filteredGroupsRestMapperProvider := NewPartialRestMapperProvider(KubernetesAppsGroup)
+		filteredGroupsMapper, err := filteredGroupsRestMapperProvider(restCfg)
+		g.Expect(err).To(gmg.Succeed())
+
+		// mapping for event expected to be found in allGroupsMapper
+		_, err = allGroupsRestMapper.RESTMapping(schema.GroupKind{Group: "events.k8s.io", Kind: "event"})
+		g.Expect(err).To(gmg.Succeed())
+		_, err = allGroupsRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"})
+		g.Expect(err).To(gmg.Succeed())
+
+		// mapping for the event expected not to be found in filteredGroupsMapper,
+		// since the predicate did not pass the events.k8s.io api group
+		_, err = filteredGroupsMapper.RESTMapping(schema.GroupKind{Group: "events.k8s.io", Kind: "event"})
+		g.Expect(err).To(gmg.HaveOccurred())
+		_, err = filteredGroupsMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"})
+		g.Expect(err).To(gmg.Succeed())
+	})
+}


### PR DESCRIPTION
This PR introduces a custom rest mapper capable of filtering API groups during the discovery procedure based on passed predicates.

Currently, the default mapper makes a lot of requests to the API server which might cause pretty long controller startup and might lead to crashes in case of network issues or slow responsive apiserver.

This code might be removed when a truly lazy rest mapper will be introduced (https://github.com/kubernetes-sigs/controller-runtime/issues/1603), or similar group filtering functionality for the discovery will be implemented in the [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime)