### PR TITLE
[OCPCLOUD-1818] Update library-go dependency to move vSphere to out of tree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+replace github.com/openshift/library-go => github.com/JoelSpeed/library-go v0.0.0-20230109105426-a2230524c08e
+
 require (
 	4d63.com/gochecknoglobals v0.1.0 // indirect
 	cloud.google.com/go/compute v1.6.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 h1:sHglBQTwgx+rW
 github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24/go.mod h1:4UJr5HIiMZrwgkSPdsjy2uOQExX/WEILpIrO9UPGuXs=
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0 h1:+r1rSv4gvYn0wmRjC8X7IAzX8QezqtFV9m0MUHFJgts=
 github.com/GaijinEntertainment/go-exhaustruct/v2 v2.3.0/go.mod h1:b3g59n2Y+T5xmcxJL+UEG2f8cQploZm1mR/v6BW0mU0=
+github.com/JoelSpeed/library-go v0.0.0-20230109105426-a2230524c08e h1:4yxWd38o6duoO3vAyYFpvpEReaBavDfTSO78+hSVF7M=
+github.com/JoelSpeed/library-go v0.0.0-20230109105426-a2230524c08e/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -528,8 +530,6 @@ github.com/openshift/api v0.0.0-20220921125526-1866ef90edbf h1:Bohu/gUxpyuTjQx2m
 github.com/openshift/api v0.0.0-20220921125526-1866ef90edbf/go.mod h1:HJAEIh4gLXPDdWxgCbvmJjzd9QIxyPZJtPU0u2W4vH4=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea h1:7JbjIzWt3Q75ErY1PAZ+gCA+bErI6HSlpffHFmMMzqM=
 github.com/openshift/client-go v0.0.0-20220831193253-4950ae70c8ea/go.mod h1:+J8DqZC60acCdpYkwVy/KH4cudgWiFZRNOBeghCzdGA=
-github.com/openshift/library-go v0.0.0-20220920133651-093893cf326b h1:LWwB7uN91G/JsMnZFd0+q6ZzAXlB4/oUOfpZWA585gw=
-github.com/openshift/library-go v0.0.0-20220920133651-093893cf326b/go.mod h1:KPBAXGaq7pPmA+1wUVtKr5Axg3R68IomWDkzaOxIhxM=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
+++ b/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
@@ -23,8 +23,7 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 	}
 	switch platformStatus.Type {
 	case configv1.AWSPlatformType,
-		configv1.GCPPlatformType,
-		configv1.VSpherePlatformType:
+		configv1.GCPPlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AzurePlatformType:
@@ -34,9 +33,11 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AlibabaCloudPlatformType,
 		configv1.IBMCloudPlatformType,
+		configv1.KubevirtPlatformType,
+		configv1.NutanixPlatformType,
 		configv1.OpenStackPlatformType,
 		configv1.PowerVSPlatformType,
-		configv1.KubevirtPlatformType:
+		configv1.VSpherePlatformType:
 		return true, nil
 	default:
 		// Platforms that do not have external cloud providers implemented

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -542,7 +542,7 @@ github.com/openshift/client-go/config/applyconfigurations/config/v1
 github.com/openshift/client-go/config/applyconfigurations/internal
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
-# github.com/openshift/library-go v0.0.0-20220920133651-093893cf326b
+# github.com/openshift/library-go v0.0.0-20220920133651-093893cf326b => github.com/JoelSpeed/library-go v0.0.0-20230109105426-a2230524c08e
 ## explicit; go 1.18
 github.com/openshift/library-go/pkg/cloudprovider
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
@@ -1384,3 +1384,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/openshift/library-go => github.com/JoelSpeed/library-go v0.0.0-20230109105426-a2230524c08e


### PR DESCRIPTION
This PR updates the library-go dependency to include [a bump to move the vSphere cloud provider to out-of-tree](https://github.com/openshift/library-go/pull/1451). Note this PR must be merged at the same time as a [PR to KCMO](https://github.com/openshift/cluster-kube-controller-manager-operator/pull/687) making the same bump to avoid a build that contains only one of the two bumps.

Tested with [cluster bot](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/release-openshift-origin-installer-launch-vsphere-modern/1612407690103885824)