### PR TITLE
Change verbosity level for some logs

### DIFF
--- a/pkg/controllers/cloud_config_sync_controller.go
+++ b/pkg/controllers/cloud_config_sync_controller.go
@@ -36,7 +36,7 @@ type CloudConfigReconciler struct {
 }
 
 func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	klog.Infof("Syncing cloud-conf ConfigMap")
+	klog.V(1).Infof("Syncing cloud-conf ConfigMap")
 
 	infra := &configv1.Infrastructure{}
 	if err := r.Get(ctx, client.ObjectKey{Name: infrastructureResourceName}, infra); err != nil {
@@ -161,7 +161,7 @@ func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Note that the source config map is actually a *transformed* source config map
 	if r.isCloudConfigEqual(sourceCM, targetCM) {
-		klog.Infof("source and target cloud-config content are equal, no sync needed")
+		klog.V(1).Infof("source and target cloud-config content are equal, no sync needed")
 		if err := r.setAvailableCondition(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
 		}
@@ -287,7 +287,7 @@ func (r *CloudConfigReconciler) setAvailableCondition(ctx context.Context) error
 	}
 
 	co.Status.Versions = []configv1.OperandVersion{{Name: operatorVersionKey, Version: r.ReleaseVersion}}
-	klog.Info("Cloud Config Controller is available")
+	klog.V(1).Info("Cloud Config Controller is available")
 	return r.syncStatus(ctx, co, conds)
 }
 

--- a/pkg/controllers/trusted_ca_bundle_controller.go
+++ b/pkg/controllers/trusted_ca_bundle_controller.go
@@ -51,7 +51,7 @@ func isSpecTrustedCASet(proxyConfig *configv1.ProxySpec) bool {
 }
 
 func (r *TrustedCABundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	klog.Infof("%s emitted event, syncing %s ConfigMap", req, trustedCAConfigMapName)
+	klog.V(1).Infof("%s emitted event, syncing %s ConfigMap", req, trustedCAConfigMapName)
 
 	proxyConfig := &configv1.Proxy{}
 	if err := r.Get(ctx, types.NamespacedName{Name: proxyResourceName}, proxyConfig); err != nil {
@@ -78,7 +78,7 @@ func (r *TrustedCABundleReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for trusted CA bundle controller: %v", err)
 		}
 
-		klog.Infof("changed config map %s is not a proxy trusted ca, skipping", req)
+		klog.V(1).Infof("changed config map %s is not a proxy trusted ca, skipping", req)
 		return reconcile.Result{}, nil
 	}
 
@@ -313,7 +313,7 @@ func (r *TrustedCABundleReconciler) setAvailableCondition(ctx context.Context) e
 	}
 
 	co.Status.Versions = []configv1.OperandVersion{{Name: operatorVersionKey, Version: r.ReleaseVersion}}
-	klog.Info("Trusted CA Bundle Controller is available")
+	klog.V(1).Info("Trusted CA Bundle Controller is available")
 	return r.syncStatus(ctx, co, conds)
 }
 


### PR DESCRIPTION
To prevent showing too many less important messages in the log we set the verbosity level for them to 1.

Here is an [example](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-cloud-controller-manager-operator/213/pull-ci-openshift-cluster-cloud-controller-manager-operator-master-e2e-gcp-ovn-ccm-install/1612583627818799104/artifacts/e2e-gcp-ovn-ccm-install/gather-extra/artifacts/pods/openshift-cloud-controller-manager-operator_cluster-cloud-controller-manager-operator-5547c7d677-t68hk_config-sync-controllers.log) of such messages.