### PR TITLE
Replace YAML parse failure warning with info message

### DIFF
--- a/pkg/cloud/vsphere/vsphere_cloud_config/config.go
+++ b/pkg/cloud/vsphere/vsphere_cloud_config/config.go
@@ -21,7 +21,8 @@ func ReadConfig(config []byte) (*CPIConfig, error) {
 	klog.V(3).Info("Try to parse vSphere config, yaml format first")
 	cfg, err := readCPIConfigYAML(config)
 	if err != nil {
-		klog.Warningf("Parsing yaml config failed, fallback to ini: %v", err)
+		klog.V(3).Info("Parsing yaml config failed, fallback to ini")
+		klog.V(4).Infof("Yaml config parsing error:\n %s", err.Error())
 
 		cfg, err = readCPIConfigINI(config)
 		if err != nil {


### PR DESCRIPTION
This warning is expectable to come. But makes a lot of noise in logs indeed.

This PR replaces warning with info log on verbosity lvl 3, error text will come out on verbosity lvl 4. 