### PR TITLE
OCPBUGS-6658: Clear useManagedIdentityExtension if it's set

### DIFF
--- a/cmd/azure-config-credentials-injector/main.go
+++ b/cmd/azure-config-credentials-injector/main.go
@@ -14,8 +14,9 @@ const (
 	clientIDEnvKey     = "AZURE_CLIENT_ID"
 	clientSecretEnvKey = "AZURE_CLIENT_SECRET"
 
-	clientIDCloudConfigKey     = "aadClientId"
-	clientSecretCloudConfigKey = "aadClientSecret"
+	clientIDCloudConfigKey               = "aadClientId"
+	clientSecretCloudConfigKey           = "aadClientSecret"
+	useManagedIdentityExtensionConfigKey = "useManagedIdentityExtension"
 )
 
 var (
@@ -26,8 +27,9 @@ var (
 	}
 
 	injectorOpts struct {
-		cloudConfigFilePath string
-		outputFilePath      string
+		cloudConfigFilePath          string
+		outputFilePath               string
+		disableIdentityExtensionAuth bool
 	}
 )
 
@@ -35,6 +37,7 @@ func init() {
 	injectorCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	injectorCmd.PersistentFlags().StringVar(&injectorOpts.cloudConfigFilePath, "cloud-config-file-path", "/tmp/cloud-config/cloud.conf", "Location of the original cloud config file.")
 	injectorCmd.PersistentFlags().StringVar(&injectorOpts.outputFilePath, "output-file-path", "/tmp/merged-cloud-config/cloud.conf", "Location of the generated cloud config file with injected credentials.")
+	injectorCmd.PersistentFlags().BoolVar(&injectorOpts.disableIdentityExtensionAuth, "disable-identity-extension-auth", false, "Disable managed identity authentication, if it's set in cloudConfig.")
 }
 
 func main() {
@@ -91,6 +94,16 @@ func readCloudConfig(path string) (map[string]interface{}, error) {
 func prepareCloudConfig(cloudConfig map[string]interface{}, clientId string, clientSecret string) ([]byte, error) {
 	cloudConfig[clientIDCloudConfigKey] = clientId
 	cloudConfig[clientSecretCloudConfigKey] = clientSecret
+	if value, found := cloudConfig[useManagedIdentityExtensionConfigKey]; found {
+		if injectorOpts.disableIdentityExtensionAuth {
+			fmt.Printf("%s cleared\n", useManagedIdentityExtensionConfigKey)
+			cloudConfig[useManagedIdentityExtensionConfigKey] = false
+		} else {
+			if value == true {
+				fmt.Printf("Warning: %s is set to \"true\", injected credentials may not be used\n", useManagedIdentityExtensionConfigKey)
+			}
+		}
+	}
 
 	marshalled, err := json.Marshal(cloudConfig)
 	if err != nil {

--- a/cmd/azure-config-credentials-injector/main.go
+++ b/cmd/azure-config-credentials-injector/main.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 )
 
 const (
@@ -34,6 +34,7 @@ var (
 )
 
 func init() {
+	klog.InitFlags(flag.CommandLine)
 	injectorCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	injectorCmd.PersistentFlags().StringVar(&injectorOpts.cloudConfigFilePath, "cloud-config-file-path", "/tmp/cloud-config/cloud.conf", "Location of the original cloud config file.")
 	injectorCmd.PersistentFlags().StringVar(&injectorOpts.outputFilePath, "output-file-path", "/tmp/merged-cloud-config/cloud.conf", "Location of the generated cloud config file with injected credentials.")
@@ -42,7 +43,7 @@ func init() {
 
 func main() {
 	if err := injectorCmd.Execute(); err != nil {
-		log.Fatal(err)
+		klog.Fatal(err)
 	}
 }
 
@@ -96,11 +97,11 @@ func prepareCloudConfig(cloudConfig map[string]interface{}, clientId string, cli
 	cloudConfig[clientSecretCloudConfigKey] = clientSecret
 	if value, found := cloudConfig[useManagedIdentityExtensionConfigKey]; found {
 		if injectorOpts.disableIdentityExtensionAuth {
-			fmt.Printf("%s cleared\n", useManagedIdentityExtensionConfigKey)
+			klog.Infof("%s cleared\n", useManagedIdentityExtensionConfigKey)
 			cloudConfig[useManagedIdentityExtensionConfigKey] = false
 		} else {
 			if value == true {
-				fmt.Printf("Warning: %s is set to \"true\", injected credentials may not be used\n", useManagedIdentityExtensionConfigKey)
+				klog.Warningf("Warning: %s is set to \"true\", injected credentials may not be used\n", useManagedIdentityExtensionConfigKey)
 			}
 		}
 	}


### PR DESCRIPTION
Add `--disable-identity-extension-auth` cmdline option to set `"useManagedIdentityExtension"` to false, because the purpose of the injector is to inject username + password into `cloud.conf` and therefore we want to use that credentials when talking to the cloud. `"useManagedIdentityExtension: true"` would use identity of the Azure VM.

cc @openshift/storage @Fedosin @lobziik 