### PR TITLE
vSphere: If only one failuredomain do not config labels

### DIFF
--- a/pkg/cloud/vsphere/vsphere_config_transformer.go
+++ b/pkg/cloud/vsphere/vsphere_config_transformer.go
@@ -45,7 +45,9 @@ func CloudConfigTransformer(source string, infra *configv1.Infrastructure, _ *co
 		setNodes(cpiCfg, &infra.Spec.PlatformSpec.VSphere.NodeNetworking)
 		setVirtualCenters(cpiCfg, infra.Spec.PlatformSpec.VSphere)
 
-		if len(infra.Spec.PlatformSpec.VSphere.FailureDomains) != 0 {
+		// labels should only be applied if length of failuredomains is
+		// greater than one so existing single (or non-zonal) installs function.
+		if len(infra.Spec.PlatformSpec.VSphere.FailureDomains) > 1 {
 			cpiCfg.Labels.Zone = zoneLabelValue
 			cpiCfg.Labels.Region = regionLabelValue
 		}


### PR DESCRIPTION
Changes to the installer to GA zonal
always create at least one failuredomain.
If labels are set and the tag or tag
categories do not exist installation boostrap
fails. To support the legacy non-zonal install
labels will only be applied when the length of
failure domains is greater than one.