### PR TITLE
OCPCLOUD-1779, OCPBUGS-8694: Set missed operator status in case of the 'External' platform type encountered

### DIFF
--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -219,6 +219,10 @@ func (r *CloudOperatorReconciler) provisioningAllowed(ctx context.Context, infra
 
 	if r.isPlatformExternal(infra.Status.PlatformStatus) {
 		klog.V(3).Info("'External' platform type is detected, do nothing.")
+		if err := r.setStatusAvailable(ctx); err != nil {
+			klog.Errorf("Unable to sync cluster operator status: %s", err)
+			return false, err
+		}
 		return false, nil
 	}
 


### PR DESCRIPTION
Follow up for
- https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/230

After #230 merged, we encountered that there is no operator status reported to cluseroperator object.
This PR adds missed status reporting.