### PR TITLE
OCPBUGS-7898: add a check for nutanix cloud conf map

### DIFF
--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -86,6 +86,12 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 		klog.Errorf("Unable to determine cluster state to check if provision is allowed: %v", err)
 		return ctrl.Result{}, err
 	} else if !allowedToProvision {
+		// we are returning early, but need to make sure we set ourselves to available so that we do not cause issues
+		if err := r.setStatusAvailable(ctx); err != nil {
+			klog.Errorf("Unable to sync cluster operator status: %s", err)
+			return ctrl.Result{}, err
+		}
+
 		return ctrl.Result{}, nil
 	}
 


### PR DESCRIPTION
When upgrading from 4.12 to 4.13 on the nutanix platform, the cloud-conf configmap must be present to avoid a degradation. This change adds a check in the cloud_config_sync_controller reconcile to check the platform type and configmap existence, if it does not exist on nutanix then the upgradeable condition will be set to false.

ref: https://issues.redhat.com/browse/OCPBUGS-7898