### PR TITLE
OCPBUGS-11284: Add beta topology labels flag to Azure cloud node manager

### DIFF
--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -63,7 +63,8 @@ spec:
               fi
               exec /bin/azure-cloud-node-manager \
                 --node-name=$(NODE_NAME) \
-                --wait-routes=false
+                --wait-routes=false \
+                --enable-deprecated-beta-topology-labels
           ports:
           - containerPort: 10263
             name: https


### PR DESCRIPTION
This enables the feature flag created in https://github.com/openshift/cloud-provider-azure/pull/62

We need this to preserve the behaviour of applying beta topology labels which have not yet been removed by openshift