### PR TITLE
revert azure out of tree cloud provider changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+replace github.com/openshift/library-go => github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e
+
 require (
 	4d63.com/gochecknoglobals v0.1.0 // indirect
 	github.com/Antonboom/errname v0.1.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -436,6 +436,8 @@ github.com/nakabonne/nestif v0.3.1 h1:wm28nZjhQY5HyYPx+weN3Q65k6ilSBxDb8v5S81B81
 github.com/nakabonne/nestif v0.3.1/go.mod h1:9EtoZochLn5iUprVDmDjqGKPofoUEBL8U4Ngq6aY7OE=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 h1:4kuARK6Y6FxaNu/BnU2OAaLF86eTVhP2hjTB6iMvItA=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
+github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e h1:84t97UoskpaRMX8esqEXbpShJjfIIvHR4izP0Fl47AM=
+github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e/go.mod h1:OspkL5FZZapzNcka6UkNMFD7ifLT/dWUNvtwErpRK9k=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nishanths/exhaustive v0.8.1 h1:0QKNascWv9qIHY7zRoZSxeRr6kuk5aAT3YXLTiDmjTo=
@@ -454,8 +456,6 @@ github.com/openshift/api v0.0.0-20230223193310-d964c7a58d75 h1:OQJsfiach1cKBI1xU
 github.com/openshift/api v0.0.0-20230223193310-d964c7a58d75/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
-github.com/openshift/library-go v0.0.0-20230308200407-f3277c772011 h1:RL6hf0cNc9uVZXQkU74a/J91XEo5iip2mWvJTwKgMg4=
-github.com/openshift/library-go v0.0.0-20230308200407-f3277c772011/go.mod h1:OspkL5FZZapzNcka6UkNMFD7ifLT/dWUNvtwErpRK9k=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=

--- a/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
+++ b/vendor/github.com/openshift/library-go/pkg/cloudprovider/external.go
@@ -25,9 +25,13 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 	case configv1.GCPPlatformType:
 		// Platforms that are external based on feature gate presence
 		return isExternalFeatureGateEnabled(featureGate)
+	case configv1.AzurePlatformType:
+		if isAzureStackHub(platformStatus) {
+			return true, nil
+		}
+		return isExternalFeatureGateEnabled(featureGate)
 	case configv1.AlibabaCloudPlatformType,
 		configv1.AWSPlatformType,
-		configv1.AzurePlatformType,
 		configv1.IBMCloudPlatformType,
 		configv1.KubevirtPlatformType,
 		configv1.NutanixPlatformType,
@@ -39,6 +43,10 @@ func IsCloudProviderExternal(platformStatus *configv1.PlatformStatus, featureGat
 		// Platforms that do not have external cloud providers implemented
 		return false, nil
 	}
+}
+
+func isAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
+	return platformStatus.Azure != nil && platformStatus.Azure.CloudName == configv1.AzureStackCloud
 }
 
 // isExternalFeatureGateEnabled determines whether the ExternalCloudProvider feature gate is present in the current

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -512,7 +512,7 @@ github.com/openshift/client-go/config/applyconfigurations/config/v1
 github.com/openshift/client-go/config/applyconfigurations/internal
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1
-# github.com/openshift/library-go v0.0.0-20230308200407-f3277c772011
+# github.com/openshift/library-go v0.0.0-20230308200407-f3277c772011 => github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e
 ## explicit; go 1.19
 github.com/openshift/library-go/pkg/cloudprovider
 github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers
@@ -1364,3 +1364,4 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
+# github.com/openshift/library-go => github.com/neisw/library-go v0.0.0-20230414134228-93654b048f4e


### PR DESCRIPTION
Reverts relevant portions of https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/231 to compare impact related to OCPBUGS-11308

Must be merged along with https://github.com/openshift/cluster-kube-controller-manager-operator/pull/723 to ensure functioning clusters.  If not merged at the same time clusters resulting from the build will be in an invalid and unstable state.