### PR TITLE
OCPBUGS-12635: fix: add workload annotation to deployments

### DIFF
--- a/pkg/cloud/alibaba/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/alibaba/assets/cloud-controller-manager-deployment.yaml
@@ -16,6 +16,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: alibaba-cloud-controller-manager
         infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         k8s-app: azure-cloud-controller-manager
         infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       serviceAccountName: cloud-controller-manager

--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -24,6 +24,7 @@ spec:
         infrastructure.openshift.io/cloud-node-manager: {{ .cloudproviderName }}
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: cloud-node-manager

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         k8s-app: azure-cloud-controller-manager
         infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       hostNetwork: true
       serviceAccountName: cloud-controller-manager

--- a/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
@@ -24,6 +24,7 @@ spec:
         infrastructure.openshift.io/cloud-node-manager: {{ .cloudproviderName }}
       annotations:
         cluster-autoscaler.kubernetes.io/daemonset-pod: "true"
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: cloud-node-manager

--- a/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
+++ b/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
@@ -16,6 +16,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: gcp-cloud-controller-manager
         infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}

--- a/pkg/cloud/ibm/assets/deployment.yaml
+++ b/pkg/cloud/ibm/assets/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: ibm-cloud-controller-manager
         infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}

--- a/pkg/cloud/nutanix/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/nutanix/assets/cloud-controller-manager-deployment.yaml
@@ -16,6 +16,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: nutanix-cloud-controller-manager
         infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}

--- a/pkg/cloud/powervs/assets/deployment.yaml
+++ b/pkg/cloud/powervs/assets/deployment.yaml
@@ -16,6 +16,8 @@ spec:
       infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: powervs-cloud-controller-manager
         infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}

--- a/pkg/cloud/vsphere/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/vsphere/assets/cloud-controller-manager-deployment.yaml
@@ -16,6 +16,8 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         k8s-app: vsphere-cloud-controller-manager
         infrastructure.openshift.io/cloud-controller-manager: {{ .cloudproviderName }}


### PR DESCRIPTION
To support the workload partitioning we need to add the required annotations (https://github.com/openshift/enhancements/pull/703).