### PR TITLE
[release-4.12] OCPBUGS-13188: update config sync controller to add upgrade status

### DIFF
--- a/pkg/controllers/cloud_config_sync_controller.go
+++ b/pkg/controllers/cloud_config_sync_controller.go
@@ -28,6 +28,8 @@ const (
 	// Controller conditions for the Cluster Operator resource
 	cloudConfigControllerAvailableCondition = "CloudConfigControllerAvailable"
 	cloudConfigControllerDegradedCondition  = "CloudConfigControllerDegraded"
+
+	upgradeAvailableMessage = "Cluster Cloud Controller Manager Operator is working as expected, no concerns about upgrading"
 )
 
 type CloudConfigReconciler struct {
@@ -76,7 +78,7 @@ func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	} else if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.Type == configv1.NutanixPlatformType {
 		// we are on Nutanix platform and the ConfigMap exists, ensure that the operator is upgradeable
-		if err := r.setUpgradeableCondition(ctx, configv1.ConditionTrue, ReasonAsExpected, ""); err != nil {
+		if err := r.setUpgradeableCondition(ctx, configv1.ConditionTrue, ReasonAsExpected, upgradeAvailableMessage); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
 		}
 
@@ -314,6 +316,8 @@ func (r *CloudConfigReconciler) setAvailableCondition(ctx context.Context) error
 			"Cloud Config Controller works as expected"),
 		newClusterOperatorStatusCondition(cloudConfigControllerDegradedCondition, configv1.ConditionFalse, ReasonAsExpected,
 			"Cloud Config Controller works as expected"),
+		newClusterOperatorStatusCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, ReasonAsExpected,
+			upgradeAvailableMessage),
 	}
 
 	co.Status.Versions = []configv1.OperandVersion{{Name: operatorVersionKey, Version: r.ReleaseVersion}}

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -511,6 +511,19 @@ var _ = Describe("Cloud config sync isProviderNutanixAndCloudConfigNeeded", func
 		Expect(needed).To(BeFalse(), "Nutanix ConfigMap should not be needed when there is no PlatformStatus")
 	})
 
+	It("should return false if the platform is None", func() {
+		// there is slightly different logic for None platform type, it uses a default switch clause
+		infraResource := makeInfrastructureResource(configv1.NonePlatformType)
+		Expect(cl.Create(ctx, infraResource)).To(Succeed())
+
+		infraResource.Status = makeInfraStatus(infraResource.Spec.PlatformSpec.Type)
+		Expect(cl.Status().Update(ctx, infraResource.DeepCopy())).To(Succeed())
+
+		needed, err := reconciler.isProviderNutanixAndCloudConfigNeeded(ctx, infraResource.Status.PlatformStatus)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(needed).To(BeFalse(), "Nutanix ConfigMap should not be needed on non-Nutanix platforms")
+	})
+
 	It("should return false if the platform is not Nutanix", func() {
 		infraResource := makeInfrastructureResource(configv1.AWSPlatformType)
 		Expect(cl.Create(ctx, infraResource)).To(Succeed())


### PR DESCRIPTION
to make the sync controller act more like the main operator controller, this PR adds the upgradeable condition as part of setting available status as ready. This is to alleviate a situation on platform none where the upgradeable status is not getting configured properly.