### PR TITLE
OCPBUGS-13862: add separate upgradeable condition for the sync controller

### DIFF
--- a/pkg/controllers/cloud_config_sync_controller.go
+++ b/pkg/controllers/cloud_config_sync_controller.go
@@ -26,8 +26,9 @@ const (
 	defaultConfigKey = "cloud.conf"
 
 	// Controller conditions for the Cluster Operator resource
-	cloudConfigControllerAvailableCondition = "CloudConfigControllerAvailable"
-	cloudConfigControllerDegradedCondition  = "CloudConfigControllerDegraded"
+	cloudConfigControllerAvailableCondition   = "CloudConfigControllerAvailable"
+	cloudConfigControllerDegradedCondition    = "CloudConfigControllerDegraded"
+	cloudConfigControllerUpgradeableCondition = "CloudConfigControllerUpgradeable"
 
 	upgradeAvailableMessage = "Cluster Cloud Controller Manager Operator is working as expected, no concerns about upgrading"
 )
@@ -316,7 +317,7 @@ func (r *CloudConfigReconciler) setAvailableCondition(ctx context.Context) error
 			"Cloud Config Controller works as expected"),
 		newClusterOperatorStatusCondition(cloudConfigControllerDegradedCondition, configv1.ConditionFalse, ReasonAsExpected,
 			"Cloud Config Controller works as expected"),
-		newClusterOperatorStatusCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, ReasonAsExpected,
+		newClusterOperatorStatusCondition(cloudConfigControllerUpgradeableCondition, configv1.ConditionTrue, ReasonAsExpected,
 			upgradeAvailableMessage),
 	}
 
@@ -350,7 +351,7 @@ func (r *CloudConfigReconciler) setUpgradeableCondition(ctx context.Context, con
 	}
 
 	conds := []configv1.ClusterOperatorStatusCondition{
-		newClusterOperatorStatusCondition(configv1.OperatorUpgradeable, condition, reason, message),
+		newClusterOperatorStatusCondition(cloudConfigControllerUpgradeableCondition, condition, reason, message),
 	}
 
 	co.Status.Versions = []configv1.OperandVersion{{Name: operatorVersionKey, Version: r.ReleaseVersion}}

--- a/pkg/controllers/status.go
+++ b/pkg/controllers/status.go
@@ -120,7 +120,9 @@ func (r *ClusterOperatorStatusClient) setStatusAvailable(ctx context.Context) er
 	upgReason := ReasonAsExpected
 	upgMessage := "Cluster Cloud Controller Manager Operator is working as expected, no concerns about upgrading"
 	for _, c := range co.Status.Conditions {
-		if c.Type == configv1.OperatorUpgradeable {
+		// if the cloud config sync controller has marked itself as non-upgradeable, the operator
+		// should also mark itself as non-upgradeable.
+		if c.Type == cloudConfigControllerUpgradeableCondition && c.Status == configv1.ConditionFalse {
 			upgradeable = c.Status
 			upgReason = c.Reason
 			upgMessage = c.Message


### PR DESCRIPTION
this change adds a separate condition for the sync controller so that primary controller can more accurately detect when the sync controller wants to mark a blocked upgrade. Separating the upgradeable condition in this manner prevents the primary controller from becoming blocked if it goes non-upgradeable due to its own issues or degraded status.

added a unit test to check that the interaction between the config sync controller and the primary controller is working the way we want.