### PR TITLE
OCPBUGS-14425: Alibaba platforms should not be upgreadable

### DIFF
--- a/pkg/controllers/cloud_config_sync_controller.go
+++ b/pkg/controllers/cloud_config_sync_controller.go
@@ -289,7 +289,7 @@ func (r *CloudConfigReconciler) setAvailableCondition(ctx context.Context) error
 
 	co.Status.Versions = []configv1.OperandVersion{{Name: operatorVersionKey, Version: r.ReleaseVersion}}
 	klog.V(1).Info("Cloud Config Controller is available")
-	return r.syncStatus(ctx, co, conds)
+	return r.syncStatus(ctx, co, conds, nil)
 }
 
 func (r *CloudConfigReconciler) setDegradedCondition(ctx context.Context) error {
@@ -307,5 +307,5 @@ func (r *CloudConfigReconciler) setDegradedCondition(ctx context.Context) error 
 
 	co.Status.Versions = []configv1.OperandVersion{{Name: operatorVersionKey, Version: r.ReleaseVersion}}
 	klog.Info("Cloud Config Controller is degraded")
-	return r.syncStatus(ctx, co, conds)
+	return r.syncStatus(ctx, co, conds, nil)
 }

--- a/pkg/controllers/trusted_ca_bundle_controller.go
+++ b/pkg/controllers/trusted_ca_bundle_controller.go
@@ -314,7 +314,7 @@ func (r *TrustedCABundleReconciler) setAvailableCondition(ctx context.Context) e
 
 	co.Status.Versions = []configv1.OperandVersion{{Name: operatorVersionKey, Version: r.ReleaseVersion}}
 	klog.V(1).Info("Trusted CA Bundle Controller is available")
-	return r.syncStatus(ctx, co, conds)
+	return r.syncStatus(ctx, co, conds, nil)
 }
 
 func (r *TrustedCABundleReconciler) setDegradedCondition(ctx context.Context) error {
@@ -332,5 +332,5 @@ func (r *TrustedCABundleReconciler) setDegradedCondition(ctx context.Context) er
 
 	co.Status.Versions = []configv1.OperandVersion{{Name: operatorVersionKey, Version: r.ReleaseVersion}}
 	klog.Info("Trusted CA Bundle Controller is degraded")
-	return r.syncStatus(ctx, co, conds)
+	return r.syncStatus(ctx, co, conds, nil)
 }


### PR DESCRIPTION
Alibaba clusters are TechPreviewNoUpgrade and should not be upgradeable.
This introduces an upgrade blocker via CCMO to prevent alibaba clusters upgrading.

The condition management in this operator sucks and needs refactoring, for now, I've made an overrides concept so that the top level operator can pass these overrides down. We should come up with a better way of doing this.