### PR TITLE
OCPBUGS-14696: Update leader election configuration for CCM to match KCM

### DIFF
--- a/pkg/cloud/alibaba/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/alibaba/assets/cloud-controller-manager-deployment.yaml
@@ -66,9 +66,9 @@ spec:
               exec /bin/alibaba-cloud-controller-manager \
               --allow-untagged-cloud=true \
               --leader-elect=true \
-              --leader-elect-lease-duration=137s \
-              --leader-elect-renew-deadline=107s \
-              --leader-elect-retry-period=26s \
+              --leader-elect-lease-duration=15s \
+              --leader-elect-renew-deadline=12s \
+              --leader-elect-retry-period=3s \
               --leader-elect-resource-namespace=openshift-cloud-controller-manager \
               --cloud-provider=alicloud \
               --use-service-account-credentials=true \

--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -38,9 +38,9 @@ spec:
           --use-service-account-credentials=true \
           --configure-cloud-routes=false \
           --leader-elect=true \
-          --leader-elect-lease-duration=137s \
-          --leader-elect-renew-deadline=107s \
-          --leader-elect-retry-period=26s \
+          --leader-elect-lease-duration=15s \
+          --leader-elect-renew-deadline=12s \
+          --leader-elect-retry-period=3s \
           --leader-elect-resource-namespace=openshift-cloud-controller-manager \
           -v=2
         image: {{ .images.CloudControllerManager }}

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -89,9 +89,9 @@ spec:
                 --bind-address=127.0.0.1 \
                 --cluster-name=$(OCP_INFRASTRUCTURE_NAME) \
                 --leader-elect=true \
-                --leader-elect-lease-duration=137s \
-                --leader-elect-renew-deadline=107s \
-                --leader-elect-retry-period=26s \
+                --leader-elect-lease-duration=15s \
+                --leader-elect-renew-deadline=12s \
+                --leader-elect-retry-period=3s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -116,9 +116,9 @@ spec:
                 --bind-address=127.0.0.1 \
                 --cluster-name=$(OCP_INFRASTRUCTURE_NAME) \
                 --leader-elect=true \
-                --leader-elect-lease-duration=137s \
-                --leader-elect-renew-deadline=107s \
-                --leader-elect-retry-period=26s \
+                --leader-elect-lease-duration=15s \
+                --leader-elect-renew-deadline=12s \
+                --leader-elect-retry-period=3s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -459,9 +459,9 @@ exec `
 func checkLeaderElection(t *testing.T, podSpec corev1.PodSpec) {
 	const (
 		leaderElect                  = "--leader-elect=true"
-		leaderElectLeaseDuration     = "--leader-elect-lease-duration=137s"
-		leaderElectRenewDeadline     = "--leader-elect-renew-deadline=107s"
-		leaderElectRetryPeriod       = "--leader-elect-retry-period=26s"
+		leaderElectLeaseDuration     = "--leader-elect-lease-duration=15s"
+		leaderElectRenewDeadline     = "--leader-elect-renew-deadline=12s"
+		leaderElectRetryPeriod       = "--leader-elect-retry-period=3s"
 		leaderElectResourceNamesapce = "--leader-elect-resource-namespace=openshift-cloud-controller-manager"
 	)
 

--- a/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
+++ b/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
@@ -91,9 +91,9 @@ spec:
                 --bind-address=127.0.0.1 \
                 --cluster-name=$(OCP_INFRASTRUCTURE_NAME) \
                 --leader-elect=true \
-                --leader-elect-lease-duration=137s \
-                --leader-elect-renew-deadline=107s \
-                --leader-elect-retry-period=26s \
+                --leader-elect-lease-duration=15s \
+                --leader-elect-renew-deadline=12s \
+                --leader-elect-retry-period=3s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/ibm/assets/deployment.yaml
+++ b/pkg/cloud/ibm/assets/deployment.yaml
@@ -84,9 +84,9 @@ spec:
             --cloud-config=/etc/ibm/cloud.conf \
             --profiling=false \
             --leader-elect=true \
-            --leader-elect-lease-duration=137s \
-            --leader-elect-renew-deadline=107s \
-            --leader-elect-retry-period=26s \
+            --leader-elect-lease-duration=15s \
+            --leader-elect-renew-deadline=12s \
+            --leader-elect-retry-period=3s \
             --leader-elect-resource-namespace=openshift-cloud-controller-manager \
             --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384 \
             --v=2

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -71,9 +71,9 @@ spec:
             --configure-cloud-routes=false \
             --bind-address=127.0.0.1 \
             --leader-elect=true \
-            --leader-elect-lease-duration=137s \
-            --leader-elect-renew-deadline=107s \
-            --leader-elect-retry-period=26s \
+            --leader-elect-lease-duration=15s \
+            --leader-elect-renew-deadline=12s \
+            --leader-elect-retry-period=3s \
             --leader-elect-resource-namespace=openshift-cloud-controller-manager
           ports:
           - containerPort: 10258

--- a/pkg/cloud/powervs/assets/deployment.yaml
+++ b/pkg/cloud/powervs/assets/deployment.yaml
@@ -84,9 +84,9 @@ spec:
             --cloud-config=/etc/ibm/cloud.conf \
             --profiling=false \
             --leader-elect=true \
-            --leader-elect-lease-duration=137s \
-            --leader-elect-renew-deadline=107s \
-            --leader-elect-retry-period=26s \
+            --leader-elect-lease-duration=15s \
+            --leader-elect-renew-deadline=12s \
+            --leader-elect-retry-period=3s \
             --leader-elect-resource-namespace=openshift-cloud-controller-manager \
             --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_256_GCM_SHA384 \
             --v=2

--- a/pkg/cloud/vsphere/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/vsphere/assets/cloud-controller-manager-deployment.yaml
@@ -92,9 +92,9 @@ spec:
                 --bind-address=127.0.0.1 \
                 --cluster-name=$(OCP_INFRASTRUCTURE_NAME) \
                 --leader-elect=true \
-                --leader-elect-lease-duration=137s \
-                --leader-elect-renew-deadline=107s \
-                --leader-elect-retry-period=26s \
+                --leader-elect-lease-duration=15s \
+                --leader-elect-renew-deadline=12s \
+                --leader-elect-retry-period=3s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager
           volumeMounts:
             - name: host-etc-kube


### PR DESCRIPTION
We are seeing long periods of downtime of the cloud controller manager during upgrades. This means that the load balancer  membership is not being updated when nodes are going down for maintenance during this period. Since this affects disruption metrics for workloads, I'm proposing we make the leader election match the kube controller manager to allow the load balancer membership to be updated more aggressively.