### PR TITLE
OpenStack: Set max-shared-lb to disable the feature

### DIFF
--- a/pkg/cloud/openstack/openstack_test.go
+++ b/pkg/cloud/openstack/openstack_test.go
@@ -179,7 +179,8 @@ use-clouds  = true
 clouds-file = /etc/openstack/secret/clouds.yaml
 cloud       = openstack
 
-[LoadBalancer]`
+[LoadBalancer]
+max-shared-lb = 1`
 				if tc.network.Status.NetworkType == string(operatorv1.NetworkTypeKuryr) {
 					expected = `[Global]
 use-clouds  = true
@@ -187,7 +188,8 @@ clouds-file = /etc/openstack/secret/clouds.yaml
 cloud       = openstack
 
 [LoadBalancer]
-enabled = false`
+enabled       = false
+max-shared-lb = 1`
 				}
 				actual := strings.TrimSpace(actual)
 				g.Expect(actual).Should(Equal(expected))


### PR DESCRIPTION
Sharing LBs in cloud-provider-openstack can have unintended consequences for the user. In particular there are potential security risks as this easily allows you to "attach" your Service to a port on an already existing FIP. Moreover there are some logic problems in handling them and feature breaks assumption that a Service can only point to pods from the same namespace, potentially breaking multitenancy.

This commit makes sure that by default OpenShift is not allowing multiple Services to share an LB. Admin can override this by explicitly setting `[LoadBalancer]max-shared-lb` in the cloud provider configuration.