### PR TITLE
OpenStack: Enable manage-security-groups by default

### DIFF
--- a/pkg/cloud/openstack/openstack.go
+++ b/pkg/cloud/openstack/openstack.go
@@ -78,6 +78,12 @@ func createLoadBalancerSection(cfg *ini.File, network *configv1.Network) error {
 	if err != nil {
 		return fmt.Errorf("failed to disable shared LBs: %w", err)
 	}
+
+	// Enable manage-security-groups by default to expose NodePorts dynamically.
+	_, err = loadBalancer.NewKey("manage-security-groups", "true")
+	if err != nil {
+		return fmt.Errorf("failed to enable managing LB members SGs: %w", err)
+	}
 	return nil
 }
 
@@ -97,6 +103,7 @@ func updateLoadBalancerSection(loadBalancer *ini.Section, network *configv1.Netw
 			enabledKey.SetValue("false")
 		}
 	}
+
 	// Disable shared LBs by default if not overriden already
 	_, err := loadBalancer.GetKey("max-shared-lb")
 	if err != nil {
@@ -104,6 +111,16 @@ func updateLoadBalancerSection(loadBalancer *ini.Section, network *configv1.Netw
 		_, err = loadBalancer.NewKey("max-shared-lb", "1")
 		if err != nil {
 			return fmt.Errorf("failed to disable shared LBs: %w", err)
+		}
+	}
+
+	// Enable manage-security-groups by default if not overriden already
+	_, err = loadBalancer.GetKey("manage-security-groups")
+	if err != nil {
+		// Allow to override this and only modify if it isn't set already.
+		_, err = loadBalancer.NewKey("manage-security-groups", "true")
+		if err != nil {
+			return fmt.Errorf("failed to enable managing LB members SGs: %w", err)
 		}
 	}
 	return nil

--- a/pkg/cloud/openstack/openstack_test.go
+++ b/pkg/cloud/openstack/openstack_test.go
@@ -159,7 +159,9 @@ secret-namespace = kube-system
 ignore-volume-az = true
 
 [LoadBalancer]
-use-octavia = false
+manage-security-groups = true
+max-shared-lb          = 1
+use-octavia            = false
 `,
 			infra:   makeInfrastructureResource(configv1.OpenStackPlatformType),
 			network: makeNetworkResource(operatorv1.NetworkTypeKuryr),
@@ -180,7 +182,8 @@ clouds-file = /etc/openstack/secret/clouds.yaml
 cloud       = openstack
 
 [LoadBalancer]
-max-shared-lb = 1`
+max-shared-lb          = 1
+manage-security-groups = true`
 				if tc.network.Status.NetworkType == string(operatorv1.NetworkTypeKuryr) {
 					expected = `[Global]
 use-clouds  = true
@@ -188,8 +191,9 @@ clouds-file = /etc/openstack/secret/clouds.yaml
 cloud       = openstack
 
 [LoadBalancer]
-enabled       = false
-max-shared-lb = 1`
+manage-security-groups = true
+max-shared-lb          = 1
+enabled                = false`
 				}
 				actual := strings.TrimSpace(actual)
 				g.Expect(actual).Should(Equal(expected))


### PR DESCRIPTION
`manage-security-groups` enables us to be more granular when allowing LB access to the cluster nodes. When enabled, CPO will create SGs dynamically for each of the LoadBalancer Services and will make sure only required NodePorts are opened on the nodes.

This also enables `loadBalancerSourceRanges` support for LBs created using OVN Octavia Provider.

This commit makes sure the option is enabled by default. Admin can override it by setting it to false manually.