### PR TITLE
OpenStack: Extend owners

### DIFF
--- a/pkg/cloud/openstack/OWNERS
+++ b/pkg/cloud/openstack/OWNERS
@@ -1,5 +1,17 @@
 approvers:
   - EmilienM
+  - MaysaMacedo
+  - dulek
+  - gryf
+  - mandre
+  - mdbooth
+  - pierreprinetti
+  - stephenfin
+reviewers:
+  - EmilienM
+  - MaysaMacedo
+  - dulek
+  - gryf
   - mandre
   - mdbooth
   - pierreprinetti


### PR DESCRIPTION
Seems like we were missing some team members from approvers. This commit adds the whole team.