### PR TITLE
OCPBUGS-16690: Allow all NoSchedule taints for Azure CNM DaemonSet

### DIFF
--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -33,7 +33,6 @@ spec:
         kubernetes.io/os: linux
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
           operator: Exists
         - effect: NoExecute
           key: node.kubernetes.io/unreachable
@@ -43,12 +42,6 @@ spec:
           key: node.kubernetes.io/not-ready
           operator: Exists
           tolerationSeconds: 120
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: Exists
       containers:
         - name: cloud-node-manager
           image: {{ .images.CloudNodeManager }}


### PR DESCRIPTION
Customers have the ability to taint nodes via MachineSets, when they do so, they can prevent the cloud-node-manager from being created on worker nodes. If they do this, then the providerID and uninitialized taint are not set and not removed. This means that pods cannot schedule on the nodes and they become wedged.

To enable wider usage of the taints feature via MachineSets, this PR moves the toleration to allow any NoSchedule taint. This should be sufficient for most use cases. I've deliberately not included NoExecute taints since I think it is valid to not run on a NoExecute for the node manager.