### PR TITLE
OCPCLOUD-2149: Azure: CCM and node manager to use provided credentials instead of MSI.

### DIFF
--- a/cmd/azure-config-credentials-injector/credentials_injector_test.go
+++ b/cmd/azure-config-credentials-injector/credentials_injector_test.go
@@ -161,7 +161,7 @@ func Test_mergeCloudConfig(t *testing.T) {
 			name:           "should fail, client secret is present while workload identity is enabled",
 			args:           []string{"--cloud-config-file-path", inputFile.Name(), "--output-file-path", outputFile.Name(), "--disable-identity-extension-auth", "--enable-azure-workload-identity=true"},
 			envVars:        map[string]string{"AZURE_TENANT_ID": "baz", "AZURE_CLIENT_ID": "foo", "AZURE_CLIENT_SECRET": "bar", "AZURE_FEDERATED_TOKEN_FILE": "baz"},
-			expectedErrMsg: "AZURE_CLIENT_SECRET env variable is set while workload identity is enabled, this should never happen.\nPlease consider reporting a bug: https://issues.redhat.com",
+			expectedErrMsg: "AZURE_CLIENT_SECRET env variable is set while workload identity is enabled using AZURE_FEDERATED_TOKEN_FILE env variable, this should never happen.\nPlease consider reporting a bug: https://issues.redhat.com",
 		},
 		{
 			name:           "should fail, workload identity can't be enabled because tenant id missing",

--- a/cmd/azure-config-credentials-injector/credentials_injector_test.go
+++ b/cmd/azure-config-credentials-injector/credentials_injector_test.go
@@ -158,22 +158,22 @@ func Test_mergeCloudConfig(t *testing.T) {
 			expectedContent: "{\"aadClientId\":\"buzz\",\"aadFederatedTokenFile\":\"baz\",\"tenantId\":\"bar\",\"useFederatedWorkloadIdentityExtension\":true}",
 		},
 		{
-			name:           "should fail, client secret is present while workload identity is enabled",
+			name:           "should fail, client secret is present while federated token file is present",
 			args:           []string{"--cloud-config-file-path", inputFile.Name(), "--output-file-path", outputFile.Name(), "--disable-identity-extension-auth", "--enable-azure-workload-identity=true"},
 			envVars:        map[string]string{"AZURE_TENANT_ID": "baz", "AZURE_CLIENT_ID": "foo", "AZURE_CLIENT_SECRET": "bar", "AZURE_FEDERATED_TOKEN_FILE": "baz"},
 			expectedErrMsg: "AZURE_CLIENT_SECRET env variable is set while workload identity is enabled using AZURE_FEDERATED_TOKEN_FILE env variable, this should never happen.\nPlease consider reporting a bug: https://issues.redhat.com",
 		},
 		{
-			name:           "should fail, workload identity can't be enabled because tenant id missing",
+			name:           "should fail, tenant id missing while federated token file is present",
 			args:           []string{"--cloud-config-file-path", inputFile.Name(), "--output-file-path", outputFile.Name(), "--disable-identity-extension-auth", "--enable-azure-workload-identity=true"},
 			envVars:        map[string]string{"AZURE_CLIENT_ID": "buzz", "AZURE_FEDERATED_TOKEN_FILE": "baz"},
-			expectedErrMsg: "workload identity method failed: AZURE_TENANT_ID environment variable not found or empty",
+			expectedErrMsg: "AZURE_TENANT_ID env variable should be set up while workload identity is enabled using AZURE_FEDERATED_TOKEN_FILE env variable, this should never happen.\nPlease consider reporting a bug: https://issues.redhat.com",
 		},
 		{
-			name:           "should fail, workload identity can't be enabled because federated token missing",
+			name:           "should fail, workload identity can't be enabled because federated token missing, expect secret provided",
 			args:           []string{"--cloud-config-file-path", inputFile.Name(), "--output-file-path", outputFile.Name(), "--disable-identity-extension-auth", "--enable-azure-workload-identity=true"},
 			envVars:        map[string]string{"AZURE_TENANT_ID": "bar", "AZURE_CLIENT_ID": "buzz"},
-			expectedErrMsg: "workload identity method failed: AZURE_FEDERATED_TOKEN_FILE environment variable not found or empty",
+			expectedErrMsg: "AZURE_CLIENT_SECRET env variable should be set up",
 		},
 	}
 

--- a/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
@@ -15,3 +15,5 @@ spec:
     kind: AzureProviderSpec
     roleBindings:
       - role: Contributor
+  serviceAccountNames:
+  - cloud-controller-manager

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -58,13 +58,19 @@ spec:
         - name: azure-inject-credentials
           image: {{ .images.CloudControllerManagerOperator }}
           command:
-            - /azure-config-credentials-injector
-          args:
-            - --cloud-config-file-path=/etc/cloud-config/cloud.conf
-            - --output-file-path=/etc/merged-cloud-config/cloud.conf
-            # Force disable node's managed identity, azure-cloud-credentials Secret should be used.
-            - --disable-identity-extension-auth
-            - --enable-azure-workload-identity=true
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              if [[ -f /etc/cloud-config/apiserver-url.env ]]; then
+                cp /etc/cloud-config/apiserver-url.env /etc/merged-cloud-config/
+              fi
+              exec /azure-config-credentials-injector \
+                --cloud-config-file-path=/etc/cloud-config/cloud.conf \
+                --output-file-path=/etc/merged-cloud-config/cloud.conf \
+                # Force disable node's managed identity, azure-cloud-credentials Secret should be used.
+                --disable-identity-extension-auth \
+                --enable-azure-workload-identity=true
           env:
             - name: AZURE_CLIENT_ID
               valueFrom:

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -68,7 +68,6 @@ spec:
               exec /azure-config-credentials-injector \
                 --cloud-config-file-path=/etc/cloud-config/cloud.conf \
                 --output-file-path=/etc/merged-cloud-config/cloud.conf \
-                # Force disable node's managed identity, azure-cloud-credentials Secret should be used.
                 --disable-identity-extension-auth \
                 --enable-azure-workload-identity=true
           env:

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -53,6 +53,48 @@ spec:
         - effect: NoSchedule
           key: node.kubernetes.io/not-ready
           operator: Exists
+      initContainers:
+        # Merge /etc/kubernetes/cloud.conf (on the host) with secret "azure-cloud-credentials" into "merged-cloud-config" emptydir.
+        - name: azure-inject-credentials
+          image: {{ .images.Operator }}
+          command:
+            - /azure-config-credentials-injector
+          args:
+            - --cloud-config-file-path=/etc/cloud-config/cloud.conf
+            - --output-file-path=/etc/merged-cloud-config/cloud.conf
+            # Force disable node's managed identity, azure-cloud-credentials Secret should be used.
+            - --disable-identity-extension-auth
+            - --enable-azure-workload-identity=true
+          env:
+            - name: AZURE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: azure-cloud-credentials
+                  key: azure_client_id
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: azure-cloud-credentials
+                  key: azure_client_secret
+                  optional: true
+            - name: AZURE_TENANT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: azure-cloud-credentials
+                  key: azure_tenant_id
+                  optional: true
+            - name: AZURE_FEDERATED_TOKEN_FILE
+              valueFrom:
+                secretKeyRef:
+                  name: azure-cloud-credentials
+                  key: azure_federated_token_file
+                  optional: true
+          volumeMounts:
+            - name: host-etc-kube
+              mountPath: /etc/cloud-config
+              readOnly: true
+            - name: merged-cloud-config
+              mountPath: /etc/merged-cloud-config
       containers:
         - name: cloud-controller-manager
           image: {{ .images.CloudControllerManager }}
@@ -94,7 +136,7 @@ spec:
                 --leader-elect-retry-period=26s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager
           volumeMounts:
-            - name: host-etc-kube
+            - name: merged-cloud-config
               mountPath: /etc/kubernetes
               readOnly: true
             - name: config-accm
@@ -102,6 +144,9 @@ spec:
               readOnly: true
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
               readOnly: true
       volumes:
         - name: config-accm
@@ -120,3 +165,11 @@ spec:
           hostPath:
             path: /etc/kubernetes
             type: Directory
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift
+        - name: merged-cloud-config
+          emptydir:

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -56,7 +56,7 @@ spec:
       initContainers:
         # Merge /etc/kubernetes/cloud.conf (on the host) with secret "azure-cloud-credentials" into "merged-cloud-config" emptydir.
         - name: azure-inject-credentials
-          image: {{ .images.Operator }}
+          image: {{ .images.CloudControllerManagerOperator }}
           command:
             - /azure-config-credentials-injector
           args:

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -95,7 +95,7 @@ spec:
                   key: azure_federated_token_file
                   optional: true
           volumeMounts:
-            - name: host-etc-kube
+            - name: config-accm
               mountPath: /etc/cloud-config
               readOnly: true
             - name: merged-cloud-config
@@ -141,10 +141,10 @@ spec:
                 --leader-elect-retry-period=26s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager
           volumeMounts:
-            - name: merged-cloud-config
+            - name: host-etc-kube
               mountPath: /etc/kubernetes
               readOnly: true
-            - name: config-accm
+            - name: merged-cloud-config
               mountPath: /etc/kubernetes-cloud-config
               readOnly: true
             - name: trusted-ca

--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -45,7 +45,7 @@ spec:
       initContainers:
         # Merge /etc/kubernetes/cloud.conf (on the host) with secret "azure-cloud-credentials" into "merged-cloud-config" emptydir.
         - name: azure-inject-credentials
-          image: {{ .images.Operator }}
+          image: {{ .images.CloudControllerManagerOperator }}
           command:
             - /azure-config-credentials-injector
           args:

--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -57,7 +57,6 @@ spec:
               exec /azure-config-credentials-injector \
                 --cloud-config-file-path=/etc/cloud-config/cloud.conf \
                 --output-file-path=/etc/merged-cloud-config/cloud.conf \
-                # Force disable node's managed identity, azure-cloud-credentials Secret should be used.
                 --disable-identity-extension-auth \
                 --enable-azure-workload-identity=true
           env:

--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -47,13 +47,19 @@ spec:
         - name: azure-inject-credentials
           image: {{ .images.CloudControllerManagerOperator }}
           command:
-            - /azure-config-credentials-injector
-          args:
-            - --cloud-config-file-path=/etc/cloud-config/cloud.conf
-            - --output-file-path=/etc/merged-cloud-config/cloud.conf
-            # Force disable node's managed identity, azure-cloud-credentials Secret should be used.
-            - --disable-identity-extension-auth
-            - --enable-azure-workload-identity=true
+            - /bin/bash
+            - -c
+            - |
+              #!/bin/bash
+              if [[ -f /etc/cloud-config/apiserver-url.env ]]; then
+                cp /etc/cloud-config/apiserver-url.env /etc/merged-cloud-config/
+              fi
+              exec /azure-config-credentials-injector \
+                --cloud-config-file-path=/etc/cloud-config/cloud.conf \
+                --output-file-path=/etc/merged-cloud-config/cloud.conf \
+                # Force disable node's managed identity, azure-cloud-credentials Secret should be used.
+                --disable-identity-extension-auth \
+                --enable-azure-workload-identity=true
           env:
             - name: AZURE_CLIENT_ID
               valueFrom:

--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -42,6 +42,48 @@ spec:
           key: node.kubernetes.io/not-ready
           operator: Exists
           tolerationSeconds: 120
+      initContainers:
+        # Merge /etc/kubernetes/cloud.conf (on the host) with secret "azure-cloud-credentials" into "merged-cloud-config" emptydir.
+        - name: azure-inject-credentials
+          image: {{ .images.Operator }}
+          command:
+            - /azure-config-credentials-injector
+          args:
+            - --cloud-config-file-path=/etc/cloud-config/cloud.conf
+            - --output-file-path=/etc/merged-cloud-config/cloud.conf
+            # Force disable node's managed identity, azure-cloud-credentials Secret should be used.
+            - --disable-identity-extension-auth
+            - --enable-azure-workload-identity=true
+          env:
+            - name: AZURE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: azure-cloud-credentials
+                  key: azure_client_id
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: azure-cloud-credentials
+                  key: azure_client_secret
+                  optional: true
+            - name: AZURE_TENANT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: azure-cloud-credentials
+                  key: azure_tenant_id
+                  optional: true
+            - name: AZURE_FEDERATED_TOKEN_FILE
+              valueFrom:
+                secretKeyRef:
+                  name: azure-cloud-credentials
+                  key: azure_federated_token_file
+                  optional: true
+          volumeMounts:
+            - name: host-etc-kube
+              mountPath: /etc/cloud-config
+              readOnly: true
+            - name: merged-cloud-config
+              mountPath: /etc/merged-cloud-config
       containers:
         - name: cloud-node-manager
           image: {{ .images.CloudNodeManager }}
@@ -69,11 +111,14 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           volumeMounts:
-            - name: host-etc-kube
+            - name: merged-cloud-config
               mountPath: /etc/kubernetes
               readOnly: true
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
               readOnly: true
           resources:
             requests:
@@ -90,3 +135,11 @@ spec:
           hostPath:
             path: /etc/kubernetes
             type: Directory
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift
+        - name: merged-cloud-config
+          emptydir:

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -24,8 +24,9 @@ var (
 )
 
 type imagesReference struct {
-	CloudControllerManager string `valid:"required"`
-	CloudNodeManager       string `valid:"required"`
+	CloudControllerManager         string `valid:"required"`
+	CloudControllerManagerOperator string `valid:"required"`
+	CloudNodeManager               string `valid:"required"`
 }
 
 var templateValuesValidationMap = map[string]interface{}{
@@ -58,8 +59,9 @@ func getTemplateValues(images *imagesReference, operatorConfig config.OperatorCo
 
 func NewProviderAssets(config config.OperatorConfig) (common.CloudProviderAssets, error) {
 	images := &imagesReference{
-		CloudControllerManager: config.ImagesReference.CloudControllerManagerAzure,
-		CloudNodeManager:       config.ImagesReference.CloudNodeManagerAzure,
+		CloudControllerManager:         config.ImagesReference.CloudControllerManagerAzure,
+		CloudControllerManagerOperator: config.ImagesReference.CloudControllerManagerOperator,
+		CloudNodeManager:               config.ImagesReference.CloudNodeManagerAzure,
 	}
 	_, err := govalidator.ValidateStruct(images)
 	if err != nil {

--- a/pkg/cloud/azure/azure_test.go
+++ b/pkg/cloud/azure/azure_test.go
@@ -19,14 +19,15 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 		{
 			name:       "Empty config",
 			config:     config.OperatorConfig{},
-			initErrMsg: "azure: missed images in config: CloudControllerManager: non zero value required;CloudNodeManager: non zero value required",
+			initErrMsg: "azure: missed images in config: CloudControllerManager: non zero value required;CloudControllerManagerOperator: non zero value required;CloudNodeManager: non zero value required",
 		}, {
 			name: "No infra config",
 			config: config.OperatorConfig{
 				ManagedNamespace: "my-cool-namespace",
 				ImagesReference: config.ImagesReference{
-					CloudControllerManagerAzure: "CloudControllerManagerAzure",
-					CloudNodeManagerAzure:       "CloudNodeManagerAzure",
+					CloudControllerManagerAzure:    "CloudControllerManagerAzure",
+					CloudNodeManagerAzure:          "CloudNodeManagerAzure",
+					CloudControllerManagerOperator: "CloudControllerManagerOperator",
 				},
 				PlatformStatus: &configv1.PlatformStatus{Type: configv1.AzurePlatformType},
 			},
@@ -36,8 +37,9 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 			config: config.OperatorConfig{
 				ManagedNamespace: "my-cool-namespace",
 				ImagesReference: config.ImagesReference{
-					CloudControllerManagerAzure: "CloudControllerManagerAzure",
-					CloudNodeManagerAzure:       "CloudNodeManagerAzure",
+					CloudControllerManagerAzure:    "CloudControllerManagerAzure",
+					CloudNodeManagerAzure:          "CloudNodeManagerAzure",
+					CloudControllerManagerOperator: "CloudControllerManagerOperator",
 				},
 				PlatformStatus:     &configv1.PlatformStatus{Type: configv1.AzurePlatformType},
 				InfrastructureName: "infra",
@@ -47,8 +49,9 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 			config: config.OperatorConfig{
 				ManagedNamespace: "my-cool-namespace",
 				ImagesReference: config.ImagesReference{
-					CloudControllerManagerAzure: "CloudControllerManagerAzure",
-					CloudNodeManagerAzure:       "CloudNodeManagerAzure",
+					CloudControllerManagerAzure:    "CloudControllerManagerAzure",
+					CloudNodeManagerAzure:          "CloudNodeManagerAzure",
+					CloudControllerManagerOperator: "CloudControllerManagerOperator",
 				},
 				PlatformStatus:     &configv1.PlatformStatus{Type: configv1.AlibabaCloudPlatformType},
 				InfrastructureName: "infra",


### PR DESCRIPTION
Modify CCM and Node Manager deployments to use the CCCMO's Azure credentials injector as an init-container to merge the provided CCO credentials secret with the `/etc/kube/cloud.conf` file used to configure [cloud-provider-azure](https://github.com/openshift/cloud-provider-azure) as used within CCM and the Node Manager. An existing example usage of the credentials injector init-container can be found within the [azure-file-csi-driver-operator](https://github.com/openshift/azure-file-csi-driver-operator/blob/066cdf4a57c08c047303d00ac8b6e777cf7a5ff9/assets/controller.yaml#L45-L86).

The CCO provided credentials secret will either contain credentials for client secret or Azure AD Workload Identity auth. Client secret is the existing default in "passthrough" credentials mode clusters. CCM and the Node Manager should be proven to be able to authenticate with client secret or a projected service account token in the case of Azure AD Workload Identity.

Additionally modify the init-container command to copy `/etc/kubernetes/apiserver-url.env` into the merged empty dir where the `cloud.conf` is written.

[OCPCLOUD-2149](https://issues.redhat.com//browse/OCPCLOUD-2149)

/hold