### PR TITLE
OCPCLOUD-2013: Move Azure Credentials Request to custom role

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
@@ -13,7 +13,15 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
-    roleBindings:
-      - role: Contributor
+    permissions:
+    - Microsoft.Compute/virtualMachines/read
+    - Microsoft.Network/loadBalancers/read
+    - Microsoft.Network/loadBalancers/write
+    - Microsoft.Network/networkInterfaces/read
+    - Microsoft.Network/networkSecurityGroups/read
+    - Microsoft.Network/networkSecurityGroups/write
+    - Microsoft.Network/publicIPAddresses/join/action
+    - Microsoft.Network/publicIPAddresses/read
+    - Microsoft.Network/publicIPAddresses/write
   serviceAccountNames:
   - cloud-controller-manager


### PR DESCRIPTION
This PR moves the Azure credentials request to use fine grained permissions rather than a generic role.

i've manually tested this and can bring up an Azure workload identity cluster with this manually. CI is covering our existing cluster bring up.