### PR TITLE
OCPBUGS-14718: Add message for CABundleControllerDegradedCondition error

### DIFF
--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -353,7 +353,7 @@ func (r *CloudOperatorReconciler) checkControllerConditions(ctx context.Context)
 	for _, cond := range co.Status.Conditions {
 		if cond.Type == cloudConfigControllerDegradedCondition || cond.Type == trustedCABundleControllerDegradedCondition {
 			if cond.Status == configv1.ConditionTrue {
-				return false, fmt.Errorf("failed to apply resources because %s condition is set to True", cond.Type)
+				return false, fmt.Errorf("failed to apply resources because %s condition is set to True: %s", cond.Type, cond.Message)
 			}
 		}
 


### PR DESCRIPTION
When deleting the project of CCCMO, we get garbage in the status of the manager which doesn't tell the user what is actually wrong. With addition of the condition message, it should be clearer for the user what is actually wrong.