### PR TITLE
OCPBUGS-18841: Additional permissions for internal load balancer on STS

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
@@ -15,9 +15,11 @@ spec:
     kind: AzureProviderSpec
     permissions:
     - Microsoft.Compute/virtualMachines/read
+    - Microsoft.Network/loadBalancers/backendAddressPools/join/action
     - Microsoft.Network/loadBalancers/read
     - Microsoft.Network/loadBalancers/write
     - Microsoft.Network/networkInterfaces/read
+    - Microsoft.Network/networkInterfaces/write
     - Microsoft.Network/networkSecurityGroups/read
     - Microsoft.Network/networkSecurityGroups/write
     - Microsoft.Network/publicIPAddresses/join/action


### PR DESCRIPTION
Managed to reproduce the issue QE were seeing by using an STS cluster, adding these two new permissions resolved the problem and the internal service got the IP it needed