### PR TITLE
OSASINFRA-3284: Add Events to OpenStack's RBAC

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_04_rbac_provider_openstack.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_04_rbac_provider_openstack.yaml
@@ -24,6 +24,13 @@ rules:
   - services
   verbs:
   - patch
+- apiGroups:
+  # Required by occm to create events
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
OpenStack keeps a separate SA definition for its CCM with a permission to patch Services. kubernetes/cloud-provider-openstack#2383 extends the needs to also be able to create events and this patch solves that.