### PR TITLE
OCPCLOUD-2278: Add kube-rbac-proxy container & ensure metrics are only available via HTTPS

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_05_metrics-service.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_05_metrics-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloud-controller-manager-operator
+  namespace: openshift-cloud-controller-manager-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    service.alpha.openshift.io/serving-cert-secret-name: cloud-controller-manager-operator-tls
+  labels:
+    app: cloud-manager-operator
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: https
+    port: 9258
+    targetPort: https
+  selector:
+    app: cloud-manager-operator
+  sessionAffinity: None

--- a/manifests/0000_26_cloud-controller-manager-operator_06_kube-rbac-proxy-config.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_06_kube-rbac-proxy-config.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+  namespace: openshift-cloud-controller-manager-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+data:
+  config-file.yaml: |+
+    authorization:
+      resourceAttributes:
+        apiVersion: v1
+        resource: namespace
+        subresource: metrics
+        namespace: openshift-cloud-controller-manager-operator

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -46,10 +46,10 @@ spec:
           --leader-elect-retry-period=26s \
           --leader-elect-resource-namespace=openshift-cloud-controller-manager-operator \
           "--images-json=/etc/cloud-controller-manager-config/images.json" \
-          --metrics-bind-address=:9258 \
+          --metrics-bind-address=127.0.0.1:9257 \
           --health-addr=127.0.0.1:9259
         ports:
-        - containerPort: 9258
+        - containerPort: 9257
           name: metrics
           protocol: TCP
         - containerPort: 9259
@@ -103,6 +103,34 @@ spec:
           - mountPath: /etc/kubernetes
             name: host-etc-kube
             readOnly: true
+      - args:
+        - --secure-listen-address=0.0.0.0:9258
+        - --upstream=http://127.0.0.1:9257/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --config-file=/etc/kube-rbac-proxy/config-file.yaml
+        - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - --logtostderr=true
+        - --v=3
+        image: quay.io/openshift/origin-kube-rbac-proxy:4.2.0
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 9258
+          name: https
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+        volumeMounts:
+        - mountPath: /etc/kube-rbac-proxy
+          name: auth-proxy-config
+        - mountPath: /etc/tls/private
+          name: cloud-manager-operator-tls
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -119,7 +119,6 @@ spec:
         - containerPort: 9258
           name: https
           protocol: TCP
-        resources: {}
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         resources:
@@ -130,7 +129,7 @@ spec:
         - mountPath: /etc/kube-rbac-proxy
           name: auth-proxy-config
         - mountPath: /etc/tls/private
-          name: cloud-manager-operator-tls
+          name: cloud-controller-manager-operator-tls
       hostNetwork: true
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -167,3 +166,10 @@ spec:
         hostPath:
           path: /etc/kubernetes
           type: Directory
+      - configMap:
+          name: kube-rbac-proxy
+        name: auth-proxy-config
+      - name: cloud-controller-manager-operator-tls
+        secret:
+          secretName: cloud-controller-manager-operator-tls
+          optional: true


### PR DESCRIPTION
This is a PR to get feedback and run tests on my changes for [OCPCLOUD-2278](https://issues.redhat.com//browse/OCPCLOUD-2278) - will add a more in depth description once we're sure it works as expected.