### PR TITLE
trt-1382: test add space

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Cluster Cloud Controller Manager Operator
-
+ 
 The Cluster Cloud Controller Manager operator (CCCMO) manages and updates the various [Cloud Controller Managers](https://kubernetes.io/docs/concepts/architecture/cloud-controller/) deployed on top of [OpenShift](https://openshift.io). The operator is based on the [Kubebuilder](https://kubebuilder.io/) framework and [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime) libraries. It is installed via [Cluster Version Operator](https://github.com/openshift/cluster-version-operator) (CVO).
 
 ## Operator Status and Supported Platforms


### PR DESCRIPTION
Testing noop to rebuild based on errors we are seeing in [4.16.0-0.nightly-2023-12-08-191525](https://amd64.ocp.releases.ci.openshift.org/releasestream/4.16.0-0.nightly/release/4.16.0-0.nightly-2023-12-08-191525)

panic: flag logtostderr set at /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/cmd/cluster-cloud-controller-manager-operator/main.go:80 before being defined

[cluster-cloud-controller-manager-operator](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.16-e2e-aws-sdn-upgrade/1733205727444471808/artifacts/e2e-aws-sdn-upgrade/gather-extra/artifacts/pods/openshift-cloud-controller-manager-operator_cluster-cloud-controller-manager-operator-77db9d5494-mdhzq_cluster-cloud-controller-manager.log)