### PR TITLE
OCPBUGS-5825: Adds GCP ClusterRole and ClusterRoleBinding

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
@@ -133,6 +133,21 @@ rules:
   verbs:
   - patch
 
+# gcp requires additional permissions on the kube-system/cloud-provider service account.
+# The operator must have these permissions to then grant them to the gcp node manager.
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - update
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -157,17 +157,23 @@ func TestGetResources(t *testing.T) {
 	}, {
 		name:                  "GCP resources returned as expected",
 		testPlatform:          platformsMap[string(configv1.GCPPlatformType)],
-		expectedResourceCount: 2,
+		expectedResourceCount: 4,
 		expectedResourcesKindName: []string{
 			"Deployment/gcp-cloud-controller-manager",
 			"PodDisruptionBudget/gcp-cloud-controller-manager",
+			"ClusterRole/gcp-cloud-controller-manager",
+			"ClusterRoleBinding/gcp-cloud-controller-manager:cloud-provider",
 		},
 	}, {
-		name:                      "GCP resources returned as expected with single node cluster",
-		testPlatform:              platformsMap[string(configv1.GCPPlatformType)],
-		expectedResourceCount:     1,
-		singleReplica:             true,
-		expectedResourcesKindName: []string{"Deployment/gcp-cloud-controller-manager"},
+		name:                  "GCP resources returned as expected with single node cluster",
+		testPlatform:          platformsMap[string(configv1.GCPPlatformType)],
+		expectedResourceCount: 3,
+		singleReplica:         true,
+		expectedResourcesKindName: []string{
+			"Deployment/gcp-cloud-controller-manager",
+			"ClusterRole/gcp-cloud-controller-manager",
+			"ClusterRoleBinding/gcp-cloud-controller-manager:cloud-provider",
+		},
 	}, {
 		name:                  "Azure resources returned as expected",
 		testPlatform:          platformsMap[string(configv1.AzurePlatformType)],

--- a/pkg/cloud/gcp/assets/gcp-cloud-controller-manager-clusterrole.yaml
+++ b/pkg/cloud/gcp/assets/gcp-cloud-controller-manager-clusterrole.yaml
@@ -1,0 +1,20 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gcp-cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+  - update

--- a/pkg/cloud/gcp/assets/gcp-cloud-controller-manager-clusterrolebinding.yaml
+++ b/pkg/cloud/gcp/assets/gcp-cloud-controller-manager-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gcp-cloud-controller-manager:cloud-provider
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gcp-cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-provider
+  namespace: kube-system

--- a/pkg/cloud/gcp/gcp.go
+++ b/pkg/cloud/gcp/gcp.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/common"
@@ -19,6 +20,8 @@ var (
 	assetsFs  embed.FS
 	templates = []common.TemplateSource{
 		{ReferenceObject: &appsv1.Deployment{}, EmbedFsPath: "assets/cloud-controller-manager.yaml"},
+		{ReferenceObject: &rbacv1.ClusterRole{}, EmbedFsPath: "assets/gcp-cloud-controller-manager-clusterrole.yaml"},
+		{ReferenceObject: &rbacv1.ClusterRoleBinding{}, EmbedFsPath: "assets/gcp-cloud-controller-manager-clusterrolebinding.yaml"},
 	}
 )
 

--- a/pkg/cloud/gcp/gcp_test.go
+++ b/pkg/cloud/gcp/gcp_test.go
@@ -55,7 +55,7 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 			}
 
 			resources := assets.GetRenderedResources()
-			assert.Len(t, resources, 1)
+			assert.Len(t, resources, 3)
 		})
 	}
 }


### PR DESCRIPTION
This change adds back the ClusterRole and ClusterRoleBinding removed in this PR [OCPBUGS-5825](https://github.com/openshift/cluster-kube-controller-manager-operator/pull/778).

This is because it is still required at present.