### PR TITLE
OCPBUGS-25483: Adds CloudConfigTransformer for Azure

### DIFF
--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -4,10 +4,12 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/asaskevich/govalidator"
 	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	azureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
@@ -26,6 +28,24 @@ var (
 		{ReferenceObject: &appsv1.Deployment{}, EmbedFsPath: "assets/cloud-controller-manager-deployment.yaml"},
 		{ReferenceObject: &appsv1.DaemonSet{}, EmbedFsPath: "assets/cloud-node-manager-daemonset.yaml"},
 	}
+)
+
+var (
+	validAzureCloudNames = map[configv1.AzureCloudEnvironment]bool{
+		configv1.AzurePublicCloud:       true,
+		configv1.AzureUSGovernmentCloud: true,
+		configv1.AzureChinaCloud:        true,
+		configv1.AzureGermanCloud:       true,
+		configv1.AzureStackCloud:        true,
+	}
+
+	validAzureCloudNameValues = func() []string {
+		v := make([]string, 0, len(validAzureCloudNames))
+		for n := range validAzureCloudNames {
+			v = append(v, string(n))
+		}
+		return v
+	}()
 )
 
 type imagesReference struct {
@@ -91,11 +111,59 @@ func NewProviderAssets(config config.OperatorConfig) (common.CloudProviderAssets
 	return assets, nil
 }
 
+func IsAzure(infra *configv1.Infrastructure) bool {
+	if infra.Status.PlatformStatus != nil &&
+		infra.Status.PlatformStatus.Type == configv1.AzurePlatformType {
+		return true
+	}
+	return false
+}
+
 func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error) {
+	if !IsAzure(infra) {
+		return "", fmt.Errorf("invalid platform, expected to be Azure")
+	}
+
 	var cfg azure.Config
 	if err := json.Unmarshal([]byte(source), &cfg); err != nil {
 		return "", fmt.Errorf("failed to unmarshal the cloud.conf: %w", err)
 	}
+
+	// We are copying the behaviour from CCO's transformer we need to:
+	// 1. Ensure that the Cloud is set in the cloud.conf
+	//   i. If it is set, verify that it is valid and does not conflict with the
+	//      infrastructure config. If it conflicts, we want to error
+	//  ii. If it is not set, default to public cloud (configv1.AzurePublicCloud)
+	//
+	// 2. Verify the cloud name set in the infra config is valid, if it is not
+	// bail with an informative error
+
+	// Verify the cloud name set in the infra config is valid
+	cloud := configv1.AzurePublicCloud
+	if azurePlatform := infra.Status.PlatformStatus.Azure; azurePlatform != nil {
+		if c := azurePlatform.CloudName; c != "" {
+			if !validAzureCloudNames[c] {
+				return "", field.NotSupported(field.NewPath("status", "platformStatus", "azure", "cloudName"), c, validAzureCloudNameValues)
+			}
+			cloud = c
+		}
+	}
+
+	// Ensure Cloud is set in cloud.conf matches what is set in infra
+	if cfg.Cloud != "" {
+		if !strings.EqualFold(string(cloud), cfg.Cloud) {
+			return "",
+				fmt.Errorf(`invalid user-provided cloud.conf: \"cloud\" field in user-provided
+				cloud.conf conflicts with infrastructure object`)
+		}
+	}
+
+	// TODO: Remove when you work this out (before merging)
+	// Why is cfg.Cloud not typed: type AzureCloudEnvironment string
+
+	// At this point these should always be the same
+	// comparrison
+	cfg.Cloud = string(cloud)
 
 	// If the virtual machine type is not set we need to make sure it uses the
 	// "standard" instance type. See OCPBUGS-25483 and OCPBUGS-20213 for more

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -112,10 +112,11 @@ func NewProviderAssets(config config.OperatorConfig) (common.CloudProviderAssets
 }
 
 func IsAzure(infra *configv1.Infrastructure) bool {
-	if infra.Status.PlatformStatus != nil &&
-		infra.Status.PlatformStatus.Type == configv1.AzurePlatformType &&
-		infra.Status.PlatformStatus.Azure.CloudName != configv1.AzureStackCloud {
-		return true
+	if infra.Status.PlatformStatus != nil {
+		if infra.Status.PlatformStatus.Type == configv1.AzurePlatformType &&
+			(infra.Status.PlatformStatus.Azure.CloudName != configv1.AzureStackCloud) {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -113,7 +113,8 @@ func NewProviderAssets(config config.OperatorConfig) (common.CloudProviderAssets
 
 func IsAzure(infra *configv1.Infrastructure) bool {
 	if infra.Status.PlatformStatus != nil &&
-		infra.Status.PlatformStatus.Type == configv1.AzurePlatformType {
+		infra.Status.PlatformStatus.Type == configv1.AzurePlatformType &&
+		infra.Status.PlatformStatus.Azure.CloudName != configv1.AzureStackCloud {
 		return true
 	}
 	return false
@@ -121,7 +122,7 @@ func IsAzure(infra *configv1.Infrastructure) bool {
 
 func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error) {
 	if !IsAzure(infra) {
-		return "", fmt.Errorf("invalid platform, expected to be Azure")
+		return "", fmt.Errorf("invalid platform, expected CloudName to be %s", configv1.AzurePublicCloud)
 	}
 
 	var cfg azure.Config

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
@@ -44,6 +45,7 @@ var (
 		for n := range validAzureCloudNames {
 			v = append(v, string(n))
 		}
+		slices.Sort(v)
 		return v
 	}()
 )

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -151,7 +151,7 @@ func CloudConfigTransformer(source string, infra *configv1.Infrastructure, netwo
 		}
 	}
 
-	// Ensure Cloud is set in cloud.conf matches what is set in infra
+	// Ensure cloud set in cloud.conf matches infra
 	if cfg.Cloud != "" {
 		if !strings.EqualFold(string(cloud), cfg.Cloud) {
 			return "",
@@ -160,12 +160,10 @@ func CloudConfigTransformer(source string, infra *configv1.Infrastructure, netwo
 		}
 	}
 
+	cfg.Cloud = string(cloud)
+
 	// TODO: Remove when you work this out (before merging)
 	// Why is cfg.Cloud not typed: type AzureCloudEnvironment string
-
-	// At this point these should always be the same
-	// comparrison
-	cfg.Cloud = string(cloud)
 
 	// If the virtual machine type is not set we need to make sure it uses the
 	// "standard" instance type. See OCPBUGS-25483 and OCPBUGS-20213 for more

--- a/pkg/cloud/azure/azure_test.go
+++ b/pkg/cloud/azure/azure_test.go
@@ -1,12 +1,23 @@
 package azure
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
+	. "github.com/onsi/gomega"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
+	ratelimitconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
+)
+
+const (
+	infraCloudConfName = "test-config"
+	infraCloudConfKey  = "foo"
 )
 
 func TestResourcesRenderingSmoke(t *testing.T) {
@@ -76,6 +87,91 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 
 			resources := assets.GetRenderedResources()
 			assert.Len(t, resources, 2)
+		})
+	}
+}
+
+func makeInfrastructureResource(platform configv1.PlatformType, cloudName configv1.AzureCloudEnvironment) *configv1.Infrastructure {
+	cfg := configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				Type: platform,
+			},
+		},
+		Spec: configv1.InfrastructureSpec{
+			CloudConfig: configv1.ConfigMapFileReference{
+				Name: infraCloudConfName,
+				Key:  infraCloudConfKey,
+			},
+			PlatformSpec: configv1.PlatformSpec{
+				Type: platform,
+			},
+		},
+	}
+
+	if platform == configv1.AzurePlatformType {
+		cfg.Status.PlatformStatus.Azure = &configv1.AzurePlatformStatus{
+			CloudName: cloudName,
+		}
+	}
+
+	return &cfg
+}
+
+// This test is a little complicated with all the JSON marshalling and
+// unmarshalling, but it is necessary due to the nature of how this data
+// is stored in Kuberenetes. The ConfigMaps containing the cloud config
+// will have string encoded JSON objects in them, due to the non-deterministic
+// natue of map object in Go we will need to examine the data instead of
+// comparing strings.
+func TestCloudConfigTransformer(t *testing.T) {
+	tc := []struct {
+		name     string
+		source   azure.Config
+		expected azure.Config
+		infra    *configv1.Infrastructure
+		errMsg   string
+	}{
+		{
+			name:     "Azure sets the vmType to standard",
+			source:   azure.Config{},
+			expected: azure.Config{VMType: "standard", AzureAuthConfig: ratelimitconfig.AzureAuthConfig{Cloud: string(configv1.AzurePublicCloud)}},
+			infra:    makeInfrastructureResource(configv1.AzurePlatformType, configv1.AzurePublicCloud),
+		},
+		{
+			name:     "Azure doesn't modify vmType if user set",
+			source:   azure.Config{VMType: "vmss"},
+			expected: azure.Config{VMType: "vmss", AzureAuthConfig: ratelimitconfig.AzureAuthConfig{Cloud: string(configv1.AzurePublicCloud)}},
+			infra:    makeInfrastructureResource(configv1.AzurePlatformType, configv1.AzurePublicCloud),
+		},
+		{
+			name:   "Non Azure returns an error",
+			source: azure.Config{},
+			infra:  makeInfrastructureResource(configv1.AzurePlatformType, configv1.AzureStackCloud),
+			errMsg: fmt.Sprintf("invalid platform, expected CloudName to be %s", configv1.AzurePublicCloud),
+		},
+	}
+
+	for _, tc := range tc {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewWithT(t)
+
+			src, err := json.Marshal(tc.source)
+			g.Expect(err).NotTo(HaveOccurred(), "Marshal of source data should succeed")
+
+			actual, err := CloudConfigTransformer(string(src), tc.infra, nil)
+			if tc.errMsg != "" {
+				g.Expect(err).Should(MatchError(tc.errMsg))
+				g.Expect(actual).Should(Equal(""))
+			} else {
+				var observed azure.Config
+				g.Expect(json.Unmarshal([]byte(actual), &observed)).To(Succeed(), "Unmarshal of observed data should succeed")
+
+				g.Expect(observed).Should(Equal(tc.expected))
+			}
 		})
 	}
 }

--- a/pkg/cloud/azure/azure_test.go
+++ b/pkg/cloud/azure/azure_test.go
@@ -11,8 +11,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	azure "sigs.k8s.io/cloud-provider-azure/pkg/provider"
 
-	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
 	ratelimitconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
+
+	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
 )
 
 const (

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -53,7 +53,6 @@ func GetCloudConfigTransformer(platformStatus *configv1.PlatformStatus) (cloudCo
 		if azurestack.IsAzureStackHub(platformStatus) {
 			return azurestack.CloudConfigTransformer, true, nil
 		}
-		// We need to use the azure CloudConfigTransformer to fix OCPBUGS-25483
 		return azure.CloudConfigTransformer, true, nil
 	case configv1.GCPPlatformType:
 		return common.NoOpTransformer, false, nil

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -53,7 +53,8 @@ func GetCloudConfigTransformer(platformStatus *configv1.PlatformStatus) (cloudCo
 		if azurestack.IsAzureStackHub(platformStatus) {
 			return azurestack.CloudConfigTransformer, true, nil
 		}
-		return nil, true, nil
+		// We need to use the azure CloudConfigTransformer to fix OCPBUGS-25483
+		return azure.CloudConfigTransformer, true, nil
 	case configv1.GCPPlatformType:
 		return common.NoOpTransformer, false, nil
 	case configv1.IBMCloudPlatformType:

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -23,6 +23,8 @@ import (
 const (
 	infraCloudConfName = "test-config"
 	infraCloudConfKey  = "foo"
+
+	defaultAzureConfig = `{"cloud":"AzurePublicCloud","tenantId":"0000000-0000-0000-0000-000000000000","subscriptionId":"0000000-0000-0000-0000-000000000000","vmType":"standard","putVMSSVMBatchSize":0,"enableMigrateToIPBasedBackendPoolAPI":false}`
 )
 
 func makeInfrastructureResource(platform configv1.PlatformType) *configv1.Infrastructure {
@@ -82,22 +84,14 @@ func makeInfraCloudConfig() *corev1.ConfigMap {
 	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 		Name:      infraCloudConfName,
 		Namespace: OpenshiftConfigNamespace,
-	}, Data: map[string]string{infraCloudConfKey: `{
-    "cloud":"AzurePublicCloud",
-    "tenantId": "0000000-0000-0000-0000-000000000000",
-    "subscriptionId": "0000000-0000-0000-0000-000000000000"
-}`}}
+	}, Data: map[string]string{infraCloudConfKey: defaultAzureConfig}}
 }
 
 func makeManagedCloudConfig() *corev1.ConfigMap {
 	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 		Name:      managedCloudConfigMapName,
 		Namespace: OpenshiftManagedConfigNamespace,
-	}, Data: map[string]string{"cloud.conf": `{
-    "cloud":"AzurePublicCloud",
-    "tenantId": "0000000-0000-0000-0000-000000000000",
-    "subscriptionId": "0000000-0000-0000-0000-000000000000"
-}`}}
+	}, Data: map[string]string{"cloud.conf": defaultAzureConfig}}
 }
 
 var _ = Describe("isCloudConfigEqual reconciler method", func() {
@@ -150,7 +144,7 @@ var _ = Describe("prepareSourceConfigMap reconciler method", func() {
 
 	It("config preparation should not touch extra fields in infra ConfigMap", func() {
 		extendedInfraConfig := infraCloudConfig.DeepCopy()
-		extendedInfraConfig.Data = map[string]string{infraCloudConfKey: "bar", "bar": "baz"}
+		extendedInfraConfig.Data = map[string]string{infraCloudConfKey: "{}", "{}": "{}"}
 		preparedConfig, err := reconciler.prepareSourceConfigMap(extendedInfraConfig, infra)
 		Expect(err).Should(Succeed())
 		_, ok := preparedConfig.Data[defaultConfigKey]
@@ -276,13 +270,14 @@ var _ = Describe("Cloud config sync controller", func() {
 			if err != nil {
 				return false, err
 			}
-			return syncedCloudConfigMap.Data[defaultConfigKey] == "bar", nil
+			return syncedCloudConfigMap.Data[defaultConfigKey] == defaultAzureConfig, nil
 		}).Should(BeTrue())
 	})
 
 	It("config should be synced up if managed cloud config changed", func() {
+		changedConfigString := `{"cloud":"AzurePublicCloud","tenantId":"0000000-1234-1234-0000-000000000000","subscriptionId":"0000000-0000-0000-0000-000000000000","vmType":"standard","putVMSSVMBatchSize":0,"enableMigrateToIPBasedBackendPoolAPI":false}`
 		changedManagedConfig := managedCloudConfig.DeepCopy()
-		changedManagedConfig.Data = map[string]string{"cloud.conf": "managed one changed"}
+		changedManagedConfig.Data = map[string]string{"cloud.conf": changedConfigString}
 		Expect(cl.Update(ctx, changedManagedConfig)).To(Succeed())
 
 		Eventually(func() (bool, error) {
@@ -291,7 +286,7 @@ var _ = Describe("Cloud config sync controller", func() {
 			if err != nil {
 				return false, err
 			}
-			return syncedCloudConfigMap.Data[defaultConfigKey] == "managed one changed", nil
+			return syncedCloudConfigMap.Data[defaultConfigKey] == changedConfigString, nil
 		}).Should(BeTrue())
 	})
 
@@ -301,14 +296,15 @@ var _ = Describe("Cloud config sync controller", func() {
 			return cl.Get(ctx, syncedConfigMapKey, syncedCloudConfigMap)
 		}, timeout).Should(Succeed())
 
-		syncedCloudConfigMap.Data = map[string]string{"foo": "baz"}
+		changedConfigString := `{"cloud":"AzurePublicCloud","tenantId":"0000000-1234-1234-0000-000000000000","subscriptionId":"0000000-0000-0000-0000-000000000000","vmType":"standard","putVMSSVMBatchSize":0,"enableMigrateToIPBasedBackendPoolAPI":false}`
+		syncedCloudConfigMap.Data = map[string]string{"foo": changedConfigString}
 		Expect(cl.Update(ctx, syncedCloudConfigMap)).To(Succeed())
 		Eventually(func() (bool, error) {
 			err := cl.Get(ctx, syncedConfigMapKey, syncedCloudConfigMap)
 			if err != nil {
 				return false, err
 			}
-			return syncedCloudConfigMap.Data[defaultConfigKey] == "bar", nil
+			return syncedCloudConfigMap.Data[defaultConfigKey] == defaultAzureConfig, nil
 		}).Should(BeTrue())
 
 		Expect(cl.Delete(ctx, syncedCloudConfigMap)).To(Succeed())
@@ -317,7 +313,7 @@ var _ = Describe("Cloud config sync controller", func() {
 			if err != nil {
 				return false, err
 			}
-			return syncedCloudConfigMap.Data[defaultConfigKey] == "bar", nil
+			return syncedCloudConfigMap.Data[defaultConfigKey] == defaultAzureConfig, nil
 		}).Should(BeTrue())
 	})
 
@@ -340,8 +336,9 @@ var _ = Describe("Cloud config sync controller", func() {
 		Expect(cl.Delete(ctx, managedCloudConfig)).Should(Succeed())
 		managedCloudConfig = nil
 
+		changedInfraConfigString := `{"cloud":"AzurePublicCloud","tenantId":"0000000-1234-1234-0000-000000000000","subscriptionId":"0000000-0000-0000-0000-000000000000","vmType":"standard","putVMSSVMBatchSize":0,"enableMigrateToIPBasedBackendPoolAPI":false}`
 		changedInfraConfig := infraCloudConfig.DeepCopy()
-		changedInfraConfig.Data = map[string]string{infraCloudConfKey: "infra one changed"}
+		changedInfraConfig.Data = map[string]string{infraCloudConfKey: changedInfraConfigString}
 		Expect(cl.Update(ctx, changedInfraConfig)).Should(Succeed())
 
 		Eventually(func() (bool, error) {
@@ -350,14 +347,16 @@ var _ = Describe("Cloud config sync controller", func() {
 			if err != nil {
 				return false, err
 			}
-			return syncedCloudConfigMap.Data[defaultConfigKey] == "infra one changed", nil
+			return syncedCloudConfigMap.Data[defaultConfigKey] == changedInfraConfigString, nil
 		}).Should(BeTrue())
 	})
 
 	It("all keys from cloud-config should be synced", func() {
+
+		changedInfraConfigString := `{"cloud":"AzurePublicCloud","tenantId":"0000000-1234-1234-0000-000000000000","subscriptionId":"0000000-0000-0000-0000-000000000000","vmType":"standard","putVMSSVMBatchSize":0,"enableMigrateToIPBasedBackendPoolAPI":false}`
 		changedManagedConfig := managedCloudConfig.DeepCopy()
 		changedManagedConfig.Data = map[string]string{
-			infraCloudConfKey: "infra config", cloudProviderConfigCABundleConfigMapKey: "some pem there",
+			infraCloudConfKey: changedInfraConfigString, cloudProviderConfigCABundleConfigMapKey: "some pem there",
 			"baz": "fizz",
 		}
 		Expect(cl.Update(ctx, changedManagedConfig)).Should(Succeed())

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -68,14 +68,22 @@ func makeInfraCloudConfig() *corev1.ConfigMap {
 	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 		Name:      infraCloudConfName,
 		Namespace: OpenshiftConfigNamespace,
-	}, Data: map[string]string{infraCloudConfKey: "bar"}}
+	}, Data: map[string]string{infraCloudConfKey: `{
+    "cloud":"AzurePublicCloud",
+    "tenantId": "0000000-0000-0000-0000-000000000000",
+    "subscriptionId": "0000000-0000-0000-0000-000000000000"
+}`}}
 }
 
 func makeManagedCloudConfig() *corev1.ConfigMap {
 	return &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
 		Name:      managedCloudConfigMapName,
 		Namespace: OpenshiftManagedConfigNamespace,
-	}, Data: map[string]string{"cloud.conf": "bar"}}
+	}, Data: map[string]string{"cloud.conf": `{
+    "cloud":"AzurePublicCloud",
+    "tenantId": "0000000-0000-0000-0000-000000000000",
+    "subscriptionId": "0000000-0000-0000-0000-000000000000"
+}`}}
 }
 
 var _ = Describe("isCloudConfigEqual reconciler method", func() {

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -54,6 +54,20 @@ func makeNetworkResource() *configv1.Network {
 }
 
 func makeInfraStatus(platform configv1.PlatformType) configv1.InfrastructureStatus {
+	if platform == configv1.AzurePlatformType {
+		return configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				Type: platform,
+				Azure: &configv1.AzurePlatformStatus{
+					CloudName: configv1.AzurePublicCloud,
+				},
+			},
+			Platform:               platform,
+			InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+			ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		}
+	}
+
 	return configv1.InfrastructureStatus{
 		PlatformStatus: &configv1.PlatformStatus{
 			Type: platform,


### PR DESCRIPTION
This adds a CloudConfigTransformer for Azure that will set the VMType to 'standard' if unset.

It also adds the functionality from the cluster-config-operator azure CloudConfigTransformer, as we can no longer rely on it by introducing this transformer.

See #291, OCPBUGS-25483 and OCPBUGS-20213 for more information.