### PR TITLE
Uses sort package in Azure ConfigTransformer

### DIFF
--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"slices"
+	"sort"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
@@ -45,7 +45,7 @@ var (
 		for n := range validAzureCloudNames {
 			v = append(v, string(n))
 		}
-		slices.Sort(v)
+		sort.Strings(v)
 		return v
 	}()
 )


### PR DESCRIPTION
This change uses the sort package, rather than the slices one that does not exist in go 1.20.