### PR TITLE
OCPBUGS-25887: IBMCloud: Patch CCM for 4.16

### DIFF
--- a/pkg/cloud/ibm/assets/deployment.yaml
+++ b/pkg/cloud/ibm/assets/deployment.yaml
@@ -59,10 +59,6 @@ spec:
         image: {{ .images.CloudControllerManager }}
         imagePullPolicy: IfNotPresent
         env:
-          - name: POD_IP_ADDRESS
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
           - name: VPCCTL_CLOUD_CONFIG
             value: /etc/ibm/cloud.conf
           - name: VPCCTL_PUBLIC_ENDPOINT
@@ -77,7 +73,7 @@ spec:
               source /etc/kubernetes/apiserver-url.env
             fi
             exec /bin/ibm-cloud-controller-manager \
-            --bind-address=$(POD_IP_ADDRESS) \
+            --bind-address=127.0.0.1 \
             --use-service-account-credentials=true \
             --configure-cloud-routes=false \
             --cloud-provider=ibm \


### PR DESCRIPTION
Drop the bind-address argument for the IBM Cloud CCM, as it is not required for operation and due to changes in OCP 4.16, Kube 1.29, attempting to bind the host node IP to the pod no longer works.