### PR TITLE
OCPBUGS-29012: Increase Azure Concurrent Service Syncs to 10

### DIFF
--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -130,6 +130,7 @@ spec:
                 --v=3 \
                 --cloud-config=$(CLOUD_CONFIG) \
                 --cloud-provider=azure \
+                --concurrent-service-syncs=10 \
                 --controllers=*,-cloud-node \
                 --configure-cloud-routes=false \
                 --use-service-account-credentials=true \


### PR DESCRIPTION
This should increase the reactiveness of the Azure service controller, meaning that creation and deletion of load balancers is quicker.

/hold

I would like to review the service controller implementation within Azure and run payload testing before we merge this