### PR TITLE
OCPBUGS-29012: Add EndpointSlices permissions for Azure

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
@@ -148,6 +148,17 @@ rules:
   verbs:
   - update
 
+# azure requires additional permissions on the openshift-cloud-controller-manager/cloud-controller-manager service account.
+# The operator must have these permissions to then grant them to the azure cloud controller manager.
+- apiGroups:
+  - "discovery.k8s.io"
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/cloud/azure/assets/azure-cloud-controller-manager-clusterrole.yaml
+++ b/pkg/cloud/azure/assets/azure-cloud-controller-manager-clusterrole.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: azure-cloud-controller-manager
+rules:
+- apiGroups:
+  - "discovery.k8s.io"
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch

--- a/pkg/cloud/azure/assets/azure-cloud-controller-manager-clusterrolebinding.yaml
+++ b/pkg/cloud/azure/assets/azure-cloud-controller-manager-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-controller-manager:azure-cloud-controller-manager
+roleRef:
+  kind: ClusterRole
+  name: azure-cloud-controller-manager
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    namespace: openshift-cloud-controller-manager
+    name: cloud-controller-manager

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -10,6 +10,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -28,6 +29,8 @@ var (
 	templates = []common.TemplateSource{
 		{ReferenceObject: &appsv1.Deployment{}, EmbedFsPath: "assets/cloud-controller-manager-deployment.yaml"},
 		{ReferenceObject: &appsv1.DaemonSet{}, EmbedFsPath: "assets/cloud-node-manager-daemonset.yaml"},
+		{ReferenceObject: &rbacv1.ClusterRole{}, EmbedFsPath: "assets/azure-cloud-controller-manager-clusterrole.yaml"},
+		{ReferenceObject: &rbacv1.ClusterRoleBinding{}, EmbedFsPath: "assets/azure-cloud-controller-manager-clusterrolebinding.yaml"},
 	}
 )
 

--- a/pkg/cloud/azure/azure_test.go
+++ b/pkg/cloud/azure/azure_test.go
@@ -90,7 +90,7 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 			}
 
 			resources := assets.GetRenderedResources()
-			assert.Len(t, resources, 2)
+			assert.Len(t, resources, 4)
 		})
 	}
 }

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -177,20 +177,24 @@ func TestGetResources(t *testing.T) {
 	}, {
 		name:                  "Azure resources returned as expected",
 		testPlatform:          platformsMap[string(configv1.AzurePlatformType)],
-		expectedResourceCount: 3,
+		expectedResourceCount: 5,
 		expectedResourcesKindName: []string{
 			"Deployment/azure-cloud-controller-manager",
 			"DaemonSet/azure-cloud-node-manager",
+			"ClusterRole/azure-cloud-controller-manager",
+			"ClusterRoleBinding/cloud-controller-manager:azure-cloud-controller-manager",
 			"PodDisruptionBudget/azure-cloud-controller-manager",
 		},
 	}, {
 		name:                  "Azure resources returned as expected with single node cluster",
 		testPlatform:          platformsMap[string(configv1.AzurePlatformType)],
-		expectedResourceCount: 2,
+		expectedResourceCount: 4,
 		singleReplica:         true,
 		expectedResourcesKindName: []string{
 			"Deployment/azure-cloud-controller-manager",
 			"DaemonSet/azure-cloud-node-manager",
+			"ClusterRole/azure-cloud-controller-manager",
+			"ClusterRoleBinding/cloud-controller-manager:azure-cloud-controller-manager",
 		},
 	}, {
 		name:                  "Azure Stack resources returned as expected",


### PR DESCRIPTION
While reviewing some logs from the attached bugs, I noticed that there were some endpointslices issues with the RBAC
```
I0202 03:17:24.210238       1 reflector.go:325] Listing and watching *v1.EndpointSlice from k8s.io/client-go/informers/factory.go:150
W0202 03:17:24.211504       1 reflector.go:535] k8s.io/client-go/informers/factory.go:150: failed to list *v1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:openshift-cloud-controller-manager:cloud-controller-manager" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
E0202 03:17:24.211538       1 reflector.go:147] k8s.io/client-go/informers/factory.go:150: Failed to watch *v1.EndpointSlice: failed to list *v1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:openshift-cloud-controller-manager:cloud-controller-manager" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope
```
So this PR should resolve those issues.