### PR TITLE
OCPBUGS-29220: Set AZURE_FEDERATED_TOKEN_FILE on CCM container

### DIFF
--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -110,6 +110,12 @@ spec:
               value: /etc/kubernetes-cloud-config/cloud.conf
             - name: OCP_INFRASTRUCTURE_NAME
               value: {{ .infrastructureName }}
+            - name: AZURE_FEDERATED_TOKEN_FILE
+              valueFrom:
+                secretKeyRef:
+                  name: azure-cloud-credentials
+                  key: azure_federated_token_file
+                  optional: true
           resources:
             requests:
               cpu: 200m


### PR DESCRIPTION
The Auth provider in the CCM has changed in 4.16 and is now relying on a different field within the Azure config, `AADClientCertPath`. It is not clear to me if this is intentional or not.

The field in the config can be overridden by setting this environment variable. It appears that this will be an easier long term fix while we ascertain if the upstream change should be reverted.