### PR TITLE
OCPBUGS-28244: Unsets ResourceManagerEndpoint for azurestack

### DIFF
--- a/pkg/cloud/azurestack/azurestack.go
+++ b/pkg/cloud/azurestack/azurestack.go
@@ -119,6 +119,11 @@ func CloudConfigTransformer(source string, infra *configv1.Infrastructure, netwo
 		cfg.VMType = azureconsts.VMTypeStandard
 	}
 
+	// Unsets ResourceManagerEndpoint in order to use endpoints.conf rather than
+	// the ResourceManagerEndpoint to build the cloud config see OCPBUGS-28244
+	// for more information
+	cfg.ResourceManagerEndpoint = ""
+
 	cfgbytes, err := json.Marshal(cfg)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal the cloud.conf: %w", err)


### PR DESCRIPTION
This change unsets the ResourceManagerEndpoint, ensuring we take the AzureCloudConfigOverrideFromEnv code path: https://github.com/openshift/cloud-provider-azure/blob/release-4.16/pkg/azclient/cloud.go#L130

This is because currently, if ResourceManagerEndpoint is set we build the config using AzureCloudConfigFromURL. 

This returns a json blob without the endpoint set, but AzureCloudConfigFromURL does not check - therefore we fail. 

```json
[
  {
    "portal": "https://portal.mtcazs.wwtatc.com/",
    "authentication": {
      "loginEndpoint": "https://login.microsoftonline.com/",
      "audiences": [
        "https://management.wwtatc.onmicrosoft.com/1d974a95-a89d-4009-9aee-8d17ddf1971d"
      ]
    },
    "graphAudience": "https://graph.windows.net/",
    "graph": "https://graph.windows.net/",
    "name": "AzureStack-User-1d974a95-a89d-4009-9aee-8d17ddf1971d",
    "suffixes": {
      "keyVaultDns": "vault.mtcazs.wwtatc.com",
      "storage": "mtcazs.wwtatc.com"
    },
    "gallery": "https://providers.azs2.local:30016/"
  }
]
```


We want to remove this once https://github.com/kubernetes-sigs/cloud-provider-azure/issues/5558 is resolved.