### PR TITLE
Bug OCPBUGS-29605: Allow to patch events in OpenStack RBAC

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_04_rbac_provider_openstack.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_04_rbac_provider_openstack.yaml
@@ -33,7 +33,7 @@ rules:
   - events
   verbs:
   - create
-
+  - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
With new events being adding to cloud-provider-openstack it's now required to also allow patching events.