### PR TITLE
OCPBUGS-13680: Pass --cluster-name to OpenStack CCM

### DIFF
--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -54,6 +54,8 @@ spec:
           env:
             - name: CLOUD_CONFIG
               value: /etc/openstack/config/cloud.conf
+            - name: OCP_INFRASTRUCTURE_NAME
+              value: {{ .infrastructureName }}
           command:
           - /bin/bash
           - -c
@@ -67,6 +69,7 @@ spec:
             --v=1 \
             --cloud-config=$(CLOUD_CONFIG) \
             --cloud-provider=openstack \
+            --cluster-name=$(OCP_INFRASTRUCTURE_NAME) \
             --use-service-account-credentials=true \
             --configure-cloud-routes=false \
             --bind-address=127.0.0.1 \

--- a/pkg/cloud/openstack/openstack.go
+++ b/pkg/cloud/openstack/openstack.go
@@ -32,9 +32,10 @@ type imagesReference struct {
 }
 
 var templateValuesValidationMap = map[string]interface{}{
-	"images":            "required",
-	"cloudproviderName": "required,type(string)",
-	"featureGates":      "type(string)",
+	"images":             "required",
+	"cloudproviderName":  "required,type(string)",
+	"featureGates":       "type(string)",
+	"infrastructureName": "required,type(string)",
 }
 
 type openstackAssets struct {
@@ -48,9 +49,10 @@ func (o *openstackAssets) GetRenderedResources() []client.Object {
 
 func getTemplateValues(images *imagesReference, operatorConfig config.OperatorConfig) (common.TemplateValues, error) {
 	values := common.TemplateValues{
-		"images":            images,
-		"cloudproviderName": operatorConfig.GetPlatformNameString(),
-		"featureGates":      operatorConfig.FeatureGates,
+		"images":             images,
+		"cloudproviderName":  operatorConfig.GetPlatformNameString(),
+		"featureGates":       operatorConfig.FeatureGates,
+		"infrastructureName": operatorConfig.InfrastructureName,
 	}
 	_, err := govalidator.ValidateMap(values, templateValuesValidationMap)
 	if err != nil {

--- a/pkg/cloud/openstack/openstack_test.go
+++ b/pkg/cloud/openstack/openstack_test.go
@@ -31,6 +31,7 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 		}, {
 			name: "Minimal allowed config",
 			config: config.OperatorConfig{
+				InfrastructureName: "infra-name",
 				ImagesReference: config.ImagesReference{
 					CloudControllerManagerOpenStack: "CloudControllerManagerOpenstack",
 				},


### PR DESCRIPTION
By an terrible oversight, since the in-tree, OpenStack cloud provider was run without passing `--cluster-name` argument, meaning that it just used the default of "kubernetes" as the cluster name when constructing the names of the LB resources. Obviously this led to conflicts when there were multiple OCP clusters in a single OpenStack tenant and it's still a challenge for example for QE running tests on a single cloud.

This issue couldn't be fixed easily, because we haven't had an upgrade story solved. Now kubernetes/cloud-provider-openstack#2552 is an attempt to make CCM rename the LBs when the cluster-name is reconfigured. This should allow us to finally solve the name conflict issues.

This commit makes sure that CCMO deploys OpenStack CCM passing `--cluster-name`.