### PR TITLE
OCPBUGS-33405: update azure and ash tolerations on node manager

### DIFF
--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -35,6 +35,9 @@ spec:
         - effect: NoSchedule
           operator: Exists
         - effect: NoExecute
+          key: node-role.kubernetes.io/infra
+          operator: Exists
+        - effect: NoExecute
           key: node.kubernetes.io/unreachable
           operator: Exists
           tolerationSeconds: 120

--- a/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
@@ -33,7 +33,9 @@ spec:
         kubernetes.io/os: linux
       tolerations:
         - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+          operator: Exists
+        - effect: NoExecute
+          key: node-role.kubernetes.io/infra
           operator: Exists
         - effect: NoExecute
           key: node.kubernetes.io/unreachable
@@ -43,12 +45,6 @@ spec:
           key: node.kubernetes.io/not-ready
           operator: Exists
           tolerationSeconds: 120
-        - effect: NoSchedule
-          key: node.cloudprovider.kubernetes.io/uninitialized
-          operator: Exists
-        - effect: NoSchedule
-          key: node.kubernetes.io/not-ready
-          operator: Exists
       initContainers:
         - name: azure-inject-credentials
           image: {{ .images.Operator }}


### PR DESCRIPTION
In our documentation, we instruct users to add a NoExecute taint for the node-role.kubernetes.io/infra key. This is not tolerated by the azure node managers and can cause a race condition when new nodes are added that can prevent the node manager from running on a new node.

This change updates the tolerations for azure and ash to allow the infra taint, and it also makes the ash permissions more tolerant (same as azure) to prevent future failures.