### PR TITLE
OCPBUGS-34689: Nutanix CCM pods Cipher Suites vulnerability issue

### DIFF
--- a/pkg/cloud/nutanix/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/nutanix/assets/cloud-controller-manager-deployment.yaml
@@ -97,7 +97,8 @@ spec:
                 --leader-elect-lease-duration=137s \
                 --leader-elect-renew-deadline=107s \
                 --leader-elect-retry-period=26s \
-                --leader-elect-resource-namespace=openshift-cloud-controller-manager
+                --leader-elect-resource-namespace=openshift-cloud-controller-manager \
+                --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: nutanix-config


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-34689
Customer running Openshift on Nutanix AHV and their Tenable Security Scan reported the following vulnerability on the Nutanix Cloud Controller Manager Deployment. 
We can resolve it by adding the "--tls-cipher-suites" option to the cli in the nutanix-ccm deployment manifest.