### PR TITLE
OCPBUGS-34938: Add cleanup timeout to unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ verify: fmt vet lint
 test: generate verify manifests unit
 
 unit:
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/bin)" ./hack/ci-test.sh
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path --bin-dir $(PROJECT_DIR)/bin --remote-bucket openshift-kubebuilder-tools)" ./hack/ci-test.sh
 
 # Build operator binaries
 build: operator config-sync-controllers azure-config-credentials-injector

--- a/pkg/controllers/resourceapply/resourceapply_test.go
+++ b/pkg/controllers/resourceapply/resourceapply_test.go
@@ -53,6 +53,7 @@ func cleanupResources(t *testing.T, g *WithT, ctx context.Context, cl client.Cli
 		g.Expect(err).ToNot(HaveOccurred())
 		g.Eventually(
 			apierrors.IsNotFound(cl.Get(ctx, key, obj)),
+			"10s",
 		).Should(BeTrue(), "Can not cleanup resources")
 	}
 


### PR DESCRIPTION
This change improves the unit tests by increasing the timeout for resource cleanups. It also adds the openshift specific bucket to the envtest command.