### PR TITLE
OCPBUGS-35798: PowerVS: Remove bind address

### DIFF
--- a/pkg/cloud/powervs/assets/deployment.yaml
+++ b/pkg/cloud/powervs/assets/deployment.yaml
@@ -73,7 +73,6 @@ spec:
               source /etc/kubernetes/apiserver-url.env
             fi
             exec /bin/ibm-cloud-controller-manager \
-            --bind-address=127.0.0.1 \
             --use-service-account-credentials=true \
             --configure-cloud-routes=false \
             --cloud-provider=ibm \


### PR DESCRIPTION
Remove the --bind-address to localhost as it makes the liveness test fail with the following error:

Liveness probe error: Get "https://192.168.169.11:10258/healthz": dial tcp 192.168.169.11:10258: connect: connection refused