### PR TITLE
OCPBUGS-22190: Add Node Admission restriction for Azure node Manager

### DIFF
--- a/cmd/cluster-cloud-controller-manager-operator/main.go
+++ b/cmd/cluster-cloud-controller-manager-operator/main.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/component-base/config"
 	"k8s.io/component-base/config/options"
 	"k8s.io/klog/v2"
-	"k8s.io/klog/v2/textlogger"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -77,8 +76,7 @@ func init() {
 }
 
 func main() {
-	textLoggerCfg := textlogger.NewConfig()
-	textLoggerCfg.AddFlags(flag.CommandLine)
+	klog.InitFlags(flag.CommandLine)
 
 	metricsAddr := flag.String(
 		"metrics-bind-address",
@@ -109,7 +107,7 @@ func main() {
 	options.BindLeaderElectionFlags(&leaderElectionConfig, pflag.CommandLine)
 	pflag.Parse()
 
-	ctrl.SetLogger(textlogger.NewLogger(textLoggerCfg).WithName("CCMOperator"))
+	ctrl.SetLogger(klog.NewKlogr().WithName("CCMOperator"))
 
 	restConfig := ctrl.GetConfigOrDie()
 	le := util.GetLeaderElectionDefaults(restConfig, configv1.LeaderElection{

--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
@@ -75,6 +75,19 @@ rules:
   - update
   - patch
 
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+
 # vSphere has a separate node manager that uses the service account kube-system/vsphere-cloud-controller-manager.
 # The operator must have these permissions to then grant them to the vSphere node manager.
 - apiGroups:

--- a/pkg/cloud/azure/assets/validating-admission-policy-binding.yaml
+++ b/pkg/cloud/azure/assets/validating-admission-policy-binding.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: openshift-cloud-controller-manager-cloud-provider-azure-node-admission
+spec:
+  policyName: openshift-cloud-controller-manager-cloud-provider-azure-node-admission
+  validationActions: ["Deny"]

--- a/pkg/cloud/azure/assets/validating-admission-policy.yaml
+++ b/pkg/cloud/azure/assets/validating-admission-policy.yaml
@@ -1,0 +1,23 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: openshift-cloud-controller-manager-cloud-provider-azure-node-admission
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   [""]
+      apiVersions: ["v1"]
+      operations:  ["UPDATE"]
+      resources:   ["nodes"]
+  validations:
+    # all requests should have a node-name claim, this prevents impersonation of the SA.
+    - expression: "has(request.userInfo.extra) && ('authentication.kubernetes.io/node-name' in request.userInfo.extra)"
+      message: "this user must have a \"authentication.kubernetes.io/node-name\" claim"
+    # all requests should originate from the MCN owner's node
+    - expression: "object.metadata.name == request.userInfo.extra[\"authentication.kubernetes.io/node-name\"][0]"
+      messageExpression: "'updates to Node ' + string(object.metadata.name) + ' may only be effected from the cloud node manager running on the same node'"      
+  matchConditions:
+    # Only check requests from Azure Cloud Node Manager SA, this allows all other SAs with the correct RBAC to modify Nodes.
+    - name: "check-only-machine-config-daemon-requests"
+      expression: "request.userInfo.username == 'system:serviceaccount:openshift-cloud-controller-manager:cloud-node-manager'"

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/asaskevich/govalidator"
 	configv1 "github.com/openshift/api/config/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -31,6 +32,8 @@ var (
 		{ReferenceObject: &appsv1.DaemonSet{}, EmbedFsPath: "assets/cloud-node-manager-daemonset.yaml"},
 		{ReferenceObject: &rbacv1.ClusterRole{}, EmbedFsPath: "assets/azure-cloud-controller-manager-clusterrole.yaml"},
 		{ReferenceObject: &rbacv1.ClusterRoleBinding{}, EmbedFsPath: "assets/azure-cloud-controller-manager-clusterrolebinding.yaml"},
+		{ReferenceObject: &admissionregistrationv1.ValidatingAdmissionPolicy{}, EmbedFsPath: "assets/validating-admission-policy.yaml"},
+		{ReferenceObject: &admissionregistrationv1.ValidatingAdmissionPolicyBinding{}, EmbedFsPath: "assets/validating-admission-policy-binding.yaml"},
 	}
 )
 

--- a/pkg/cloud/azure/azure_test.go
+++ b/pkg/cloud/azure/azure_test.go
@@ -90,7 +90,7 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 			}
 
 			resources := assets.GetRenderedResources()
-			assert.Len(t, resources, 4)
+			assert.Len(t, resources, 6)
 		})
 	}
 }

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -149,24 +149,28 @@ func TestGetResources(t *testing.T) {
 	}, {
 		name:                  "Azure resources returned as expected",
 		testPlatform:          platformsMap[string(configv1.AzurePlatformType)],
-		expectedResourceCount: 5,
+		expectedResourceCount: 7,
 		expectedResourcesKindName: []string{
 			"Deployment/azure-cloud-controller-manager",
 			"DaemonSet/azure-cloud-node-manager",
 			"ClusterRole/azure-cloud-controller-manager",
 			"ClusterRoleBinding/cloud-controller-manager:azure-cloud-controller-manager",
+			"ValidatingAdmissionPolicy/openshift-cloud-controller-manager-cloud-provider-azure-node-admission",
+			"ValidatingAdmissionPolicyBinding/openshift-cloud-controller-manager-cloud-provider-azure-node-admission",
 			"PodDisruptionBudget/azure-cloud-controller-manager",
 		},
 	}, {
 		name:                  "Azure resources returned as expected with single node cluster",
 		testPlatform:          platformsMap[string(configv1.AzurePlatformType)],
-		expectedResourceCount: 4,
+		expectedResourceCount: 6,
 		singleReplica:         true,
 		expectedResourcesKindName: []string{
 			"Deployment/azure-cloud-controller-manager",
 			"DaemonSet/azure-cloud-node-manager",
 			"ClusterRole/azure-cloud-controller-manager",
 			"ClusterRoleBinding/cloud-controller-manager:azure-cloud-controller-manager",
+			"ValidatingAdmissionPolicy/openshift-cloud-controller-manager-cloud-provider-azure-node-admission",
+			"ValidatingAdmissionPolicyBinding/openshift-cloud-controller-manager-cloud-provider-azure-node-admission",
 		},
 	}, {
 		name:                  "Azure Stack resources returned as expected",


### PR DESCRIPTION
This PR adds a policy for the Azure cloud node manager that prevents the node manager on one node, from applying updates to other Node objects. This mirrors the Kubelet node admission that prevents kubelets from updating each other.

This is not expected to cause any issues with the node manager as they should never be cross communicating anyway, but, does prevent escalation should the node manager service account become compromised.

It also includes a fix to the klog which I realised was missing (we have no logs on the CCMO in recent times)