### PR TITLE
OCPBUGS-43164: set goimport version to v0.24.0

### DIFF
--- a/hack/goimports.sh
+++ b/hack/goimports.sh
@@ -7,7 +7,7 @@ REPO_ROOT=$(realpath "$(dirname "${BASH_SOURCE[0]}")/..")
 
 function runGoimports() {
   local GOIMPORTS_PATH=$REPO_ROOT/bin/goimports
-  GOBIN="$REPO_ROOT"/bin go install -mod=readonly golang.org/x/tools/cmd/goimports@latest
+  GOBIN="$REPO_ROOT"/bin go install -mod=readonly golang.org/x/tools/cmd/goimports@v0.24.0
 
   local LOCAL_PACKAGE="github.com/openshift/cluster-cloud-controller-manager-operator"
   local GOIMPORTS_ARGS=("-local $LOCAL_PACKAGE -w $REPO_ROOT/cmd $REPO_ROOT/pkg")


### PR DESCRIPTION
This change is being proposed because the release-4.16 branch uses golang version 1.21 and the versions of goimports greater than 0.24.0 require golang version 1.22+.