### PR TITLE
OCPCLOUD-2844: Add role/binding for new Azure AKS lease

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
@@ -275,6 +275,35 @@ rules:
       - get
       - list
       - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cluster-cloud-controller-manager
+  namespace: kube-system
+  annotations:
+    capability.openshift.io/name: CloudControllerManager
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  # Azure needs these permissions, so to be able to install them, the operator needs them too.
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - aks-managed-resource-locker
+    verbs:
+      - get
+      - list
+      - update
+  # Create cannot be restricted by resource name
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -345,6 +374,25 @@ metadata:
 roleRef:
   kind: ClusterRole
   name: admin
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    namespace: openshift-cloud-controller-manager-operator
+    name: cluster-cloud-controller-manager
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cluster-cloud-controller-manager
+  namespace: kube-system
+  annotations:
+    capability.openshift.io/name: CloudControllerManager
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  kind: Role
+  name: cluster-cloud-controller-manager
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount

--- a/pkg/cloud/azure/assets/azure-cloud-provider-role.yaml
+++ b/pkg/cloud/azure/assets/azure-cloud-provider-role.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: azure-cloud-provider
+  namespace: kube-system
+  annotations:
+    capability.openshift.io/name: CloudControllerManager
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - aks-managed-resource-locker
+    verbs:
+      - get
+      - list
+      - update
+  # Create cannot be restricted by resource name
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create

--- a/pkg/cloud/azure/assets/azure-cloud-provider-rolebinding.yaml
+++ b/pkg/cloud/azure/assets/azure-cloud-provider-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: azure-cloud-provider:azure-cloud-provider
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: azure-cloud-provider
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    namespace: kube-system
+    name: azure-cloud-provider

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -30,6 +30,8 @@ var (
 	templates = []common.TemplateSource{
 		{ReferenceObject: &appsv1.Deployment{}, EmbedFsPath: "assets/cloud-controller-manager-deployment.yaml"},
 		{ReferenceObject: &appsv1.DaemonSet{}, EmbedFsPath: "assets/cloud-node-manager-daemonset.yaml"},
+		{ReferenceObject: &rbacv1.Role{}, EmbedFsPath: "assets/azure-cloud-provider-role.yaml"},
+		{ReferenceObject: &rbacv1.RoleBinding{}, EmbedFsPath: "assets/azure-cloud-provider-rolebinding.yaml"},
 		{ReferenceObject: &rbacv1.ClusterRole{}, EmbedFsPath: "assets/azure-cloud-controller-manager-clusterrole.yaml"},
 		{ReferenceObject: &rbacv1.ClusterRoleBinding{}, EmbedFsPath: "assets/azure-cloud-controller-manager-clusterrolebinding.yaml"},
 		{ReferenceObject: &admissionregistrationv1.ValidatingAdmissionPolicy{}, EmbedFsPath: "assets/validating-admission-policy.yaml"},

--- a/pkg/cloud/azure/azure_test.go
+++ b/pkg/cloud/azure/azure_test.go
@@ -90,7 +90,7 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 			}
 
 			resources := assets.GetRenderedResources()
-			assert.Len(t, resources, 6)
+			assert.Len(t, resources, 8)
 		})
 	}
 }

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -149,10 +149,12 @@ func TestGetResources(t *testing.T) {
 	}, {
 		name:                  "Azure resources returned as expected",
 		testPlatform:          platformsMap[string(configv1.AzurePlatformType)],
-		expectedResourceCount: 7,
+		expectedResourceCount: 9,
 		expectedResourcesKindName: []string{
 			"Deployment/azure-cloud-controller-manager",
 			"DaemonSet/azure-cloud-node-manager",
+			"Role/azure-cloud-provider",
+			"RoleBinding/azure-cloud-provider:azure-cloud-provider",
 			"ClusterRole/azure-cloud-controller-manager",
 			"ClusterRoleBinding/cloud-controller-manager:azure-cloud-controller-manager",
 			"ValidatingAdmissionPolicy/openshift-cloud-controller-manager-cloud-provider-azure-node-admission",
@@ -162,11 +164,13 @@ func TestGetResources(t *testing.T) {
 	}, {
 		name:                  "Azure resources returned as expected with single node cluster",
 		testPlatform:          platformsMap[string(configv1.AzurePlatformType)],
-		expectedResourceCount: 6,
+		expectedResourceCount: 8,
 		singleReplica:         true,
 		expectedResourcesKindName: []string{
 			"Deployment/azure-cloud-controller-manager",
 			"DaemonSet/azure-cloud-node-manager",
+			"Role/azure-cloud-provider",
+			"RoleBinding/azure-cloud-provider:azure-cloud-provider",
 			"ClusterRole/azure-cloud-controller-manager",
 			"ClusterRoleBinding/cloud-controller-manager:azure-cloud-controller-manager",
 			"ValidatingAdmissionPolicy/openshift-cloud-controller-manager-cloud-provider-azure-node-admission",


### PR DESCRIPTION
The current rebase is failing on a [lack of permission](https://github.com/openshift/cloud-provider-azure/pull/127#issuecomment-2598187091) for a new lease that the Azure CCM is trying to leverage.

This role/rolebinding fills the gap in permissions.