### PR TITLE
OCPCLOUD-2843: AWS CCM should be configured with the AWS cloud provider config

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -34,6 +34,7 @@ spec:
             source /etc/kubernetes/apiserver-url.env
           fi
           exec /bin/aws-cloud-controller-manager \
+          --cloud-config=$(CLOUD_CONFIG) \
           --cloud-provider=aws \
           --use-service-account-credentials=true \
           --configure-cloud-routes=false \
@@ -43,6 +44,9 @@ spec:
           --leader-elect-retry-period=26s \
           --leader-elect-resource-namespace=openshift-cloud-controller-manager \
           -v=2
+        env:
+        - name: CLOUD_CONFIG
+          value: /etc/kubernetes-cloud-config/cloud.conf
         image: {{ .images.CloudControllerManager }}
         imagePullPolicy: IfNotPresent
         name: cloud-controller-manager
@@ -58,6 +62,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/kubernetes
           name: host-etc-kube
+          readOnly: true
+        - name: config-accm
+          mountPath: /etc/kubernetes-cloud-config
           readOnly: true
         - name: trusted-ca
           mountPath: /etc/pki/ca-trust/extracted/pem
@@ -93,6 +100,12 @@ spec:
         key: node.kubernetes.io/not-ready
         operator: Exists
       volumes:
+      - name: config-accm
+        configMap:
+          name: cloud-conf
+          items:
+            - key: cloud.conf
+              path: cloud.conf
       - name: trusted-ca
         configMap:
           name: ccm-trusted-ca


### PR DESCRIPTION
I recently update the AWS CCM to set the load balancer, cluster scoped health checks to port 10256 and /healthz. It turns out, that even though the tests looked good, this config change was not being consumed by the CCM. We did not even pass the configmap into the AWS CCM.

I've tested this manually and when configuring the below, I can now see that the configmap options are honoured, and the health checks appear as expected.