### PR TITLE
OCPBUGS-41827: update injector to support secret as well

### DIFF
--- a/cmd/azure-config-credentials-injector/credentials_injector_test.go
+++ b/cmd/azure-config-credentials-injector/credentials_injector_test.go
@@ -72,13 +72,13 @@ func Test_mergeCloudConfig(t *testing.T) {
 		{
 			name:           "AZURE_CLIENT_ID not set",
 			args:           []string{"--cloud-config-file-path", inputFile.Name(), "--output-file-path", outputFile.Name()},
-			expectedErrMsg: "AZURE_CLIENT_ID env variable should be set up",
+			expectedErrMsg: "azure_client_id should be set up",
 		},
 		{
 			name:           "AZURE_CLIENT_SECRET not set",
 			args:           []string{"--cloud-config-file-path", inputFile.Name(), "--output-file-path", outputFile.Name()},
 			envVars:        map[string]string{"AZURE_CLIENT_ID": "foo"},
-			expectedErrMsg: "AZURE_CLIENT_SECRET env variable should be set up",
+			expectedErrMsg: "azure_client_secret should be set up",
 		},
 		{
 			name:           "input file content is not a valid json",
@@ -161,19 +161,19 @@ func Test_mergeCloudConfig(t *testing.T) {
 			name:           "should fail, client secret is present while federated token file is present",
 			args:           []string{"--cloud-config-file-path", inputFile.Name(), "--output-file-path", outputFile.Name(), "--disable-identity-extension-auth", "--enable-azure-workload-identity=true"},
 			envVars:        map[string]string{"AZURE_TENANT_ID": "baz", "AZURE_CLIENT_ID": "foo", "AZURE_CLIENT_SECRET": "bar", "AZURE_FEDERATED_TOKEN_FILE": "baz"},
-			expectedErrMsg: "AZURE_CLIENT_SECRET env variable is set while workload identity is enabled using AZURE_FEDERATED_TOKEN_FILE env variable, this should never happen.\nPlease consider reporting a bug: https://issues.redhat.com",
+			expectedErrMsg: "azure_client_secret is set while workload identity is enabled using azure_federated_token_file, this should never happen.\nPlease consider reporting a bug: https://issues.redhat.com",
 		},
 		{
 			name:           "should fail, tenant id missing while federated token file is present",
 			args:           []string{"--cloud-config-file-path", inputFile.Name(), "--output-file-path", outputFile.Name(), "--disable-identity-extension-auth", "--enable-azure-workload-identity=true"},
 			envVars:        map[string]string{"AZURE_CLIENT_ID": "buzz", "AZURE_FEDERATED_TOKEN_FILE": "baz"},
-			expectedErrMsg: "AZURE_TENANT_ID env variable should be set up while workload identity is enabled using AZURE_FEDERATED_TOKEN_FILE env variable, this should never happen.\nPlease consider reporting a bug: https://issues.redhat.com",
+			expectedErrMsg: "azure_tenant_id should be set up while workload identity is enabled using azure_federated_token_file, this should never happen.\nPlease consider reporting a bug: https://issues.redhat.com",
 		},
 		{
 			name:           "should fail, workload identity can't be enabled because federated token missing, expect secret provided",
 			args:           []string{"--cloud-config-file-path", inputFile.Name(), "--output-file-path", outputFile.Name(), "--disable-identity-extension-auth", "--enable-azure-workload-identity=true"},
 			envVars:        map[string]string{"AZURE_TENANT_ID": "bar", "AZURE_CLIENT_ID": "buzz"},
-			expectedErrMsg: "AZURE_CLIENT_SECRET env variable should be set up",
+			expectedErrMsg: "azure_client_secret should be set up",
 		},
 	}
 

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -69,7 +69,8 @@ spec:
                 --cloud-config-file-path=/etc/cloud-config/cloud.conf \
                 --output-file-path=/etc/merged-cloud-config/cloud.conf \
                 --disable-identity-extension-auth \
-                --enable-azure-workload-identity=true
+                --enable-azure-workload-identity=true \
+                --creds-path=/etc/azure/credentials
           env:
             - name: AZURE_CLIENT_ID
               valueFrom:
@@ -101,6 +102,9 @@ spec:
               readOnly: true
             - name: merged-cloud-config
               mountPath: /etc/merged-cloud-config
+            - name: cloud-sa-volume
+              mountPath: /etc/azure/credentials
+              readOnly: true
       containers:
         - name: cloud-controller-manager
           image: {{ .images.CloudControllerManager }}
@@ -156,6 +160,9 @@ spec:
             - name: merged-cloud-config
               mountPath: /etc/kubernetes-cloud-config
               readOnly: true
+            - name: cloud-sa-volume
+              readOnly: true
+              mountPath: /etc/azure/credentials
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
               readOnly: true
@@ -169,6 +176,9 @@ spec:
             items:
               - key: cloud.conf
                 path: cloud.conf
+        - name: cloud-sa-volume
+          secret:
+            secretName: azure-cloud-credentials
         - name: trusted-ca
           configMap:
             name: ccm-trusted-ca

--- a/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azure/assets/cloud-node-manager-daemonset.yaml
@@ -61,7 +61,8 @@ spec:
                 --cloud-config-file-path=/etc/cloud-config/cloud.conf \
                 --output-file-path=/etc/merged-cloud-config/cloud.conf \
                 --disable-identity-extension-auth \
-                --enable-azure-workload-identity=true
+                --enable-azure-workload-identity=true \
+                --creds-path=/etc/azure/credentials
           env:
             - name: AZURE_CLIENT_ID
               valueFrom:
@@ -93,6 +94,9 @@ spec:
               readOnly: true
             - name: merged-cloud-config
               mountPath: /etc/merged-cloud-config
+            - name: cloud-sa-volume
+              mountPath: /etc/azure/credentials
+              readOnly: true
       containers:
         - name: cloud-node-manager
           image: {{ .images.CloudNodeManager }}
@@ -135,6 +139,9 @@ spec:
               cpu: 50m
               memory: 50Mi
       volumes:
+        - name: cloud-sa-volume
+          secret:
+            secretName: azure-cloud-credentials
         - name: trusted-ca
           configMap:
             name: ccm-trusted-ca

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -61,6 +61,7 @@ spec:
           args:
             - --cloud-config-file-path=/tmp/cloud-config/cloud.conf
             - --output-file-path=/tmp/merged-cloud-config/cloud.conf
+            - --creds-path=/etc/azure/credentials
           env:
             - name: AZURE_CLIENT_ID
               valueFrom:
@@ -79,6 +80,9 @@ spec:
               readOnly: true
             - name: cloud-config
               mountPath: /tmp/merged-cloud-config
+            - name: cloud-sa-volume
+              mountPath: /etc/azure/credentials
+              readOnly: true
       containers:
         - name: cloud-controller-manager
           image: {{ .images.CloudControllerManager }}
@@ -148,6 +152,9 @@ spec:
           hostPath:
             path: /etc/kubernetes
             type: Directory
+        - name: cloud-sa-volume
+          secret:
+            secretName: azure-cloud-credentials
         - name: trusted-ca
           configMap:
             name: ccm-trusted-ca

--- a/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-node-manager-daemonset.yaml
@@ -53,6 +53,7 @@ spec:
           args:
             - --cloud-config-file-path=/tmp/cloud-config/cloud.conf
             - --output-file-path=/tmp/merged-cloud-config/cloud.conf
+            - --creds-path=/etc/azure/credentials
           env:
             - name: AZURE_CLIENT_ID
               valueFrom:
@@ -71,6 +72,9 @@ spec:
               readOnly: true
             - name: cloud-config
               mountPath: /tmp/merged-cloud-config
+            - name: cloud-sa-volume
+              mountPath: /etc/azure/credentials
+              readOnly: true
       containers:
         - name: cloud-node-manager
           image: {{ .images.CloudNodeManager }}
@@ -134,6 +138,9 @@ spec:
                 path: cloud.conf
               - key: endpoints
                 path: endpoints.conf
+        - name: cloud-sa-volume
+          secret:
+            secretName: azure-cloud-credentials
         - name: trusted-ca
           configMap:
             name: ccm-trusted-ca


### PR DESCRIPTION
Based on discussion https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/380#issuecomment-2668448871  this pr will keep both the secret and environment variables methods, this pr need to be merged first, then openshift/csi-operator#357, then remove environment variables https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/380

Built image [build 4.18,openshift/cluster-cloud-controller-manager-operator#385](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1894239232529010688) and installed cluster on azure and ash, cluster install succeed.
Built image [build 4.18,openshift/cluster-cloud-controller-manager-operator#385, openshift/csi-operator#357](https://prow.ci.openshift.org/view/gs/test-platform-results/logs/release-openshift-origin-installer-launch-aws-modern/1894239702202978304) and installed cluster on azure and ash, cluster install succeed.