### PR TITLE
OCPBUGS-54427: Add rbac leases rbac for cloud-provider on Azure stack hub

### DIFF
--- a/pkg/cloud/azurestack/assets/azure-cloud-provider-role.yaml
+++ b/pkg/cloud/azurestack/assets/azure-cloud-provider-role.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: azure-cloud-provider
+  namespace: kube-system
+  annotations:
+    capability.openshift.io/name: CloudControllerManager
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    resourceNames:
+      - aks-managed-resource-locker
+    verbs:
+      - get
+      - list
+      - update
+  # Create cannot be restricted by resource name
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create

--- a/pkg/cloud/azurestack/assets/azure-cloud-provider-rolebinding.yaml
+++ b/pkg/cloud/azurestack/assets/azure-cloud-provider-rolebinding.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: azure-cloud-provider:azure-cloud-provider
+  namespace: kube-system
+roleRef:
+  kind: Role
+  name: azure-cloud-provider
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    namespace: kube-system
+    name: azure-cloud-provider

--- a/pkg/cloud/azurestack/azurestack.go
+++ b/pkg/cloud/azurestack/azurestack.go
@@ -8,6 +8,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	azureconsts "sigs.k8s.io/cloud-provider-azure/pkg/consts"
 	azureconfig "sigs.k8s.io/cloud-provider-azure/pkg/provider/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -24,6 +25,8 @@ var (
 	templates = []common.TemplateSource{
 		{ReferenceObject: &appsv1.Deployment{}, EmbedFsPath: "assets/cloud-controller-manager-deployment.yaml"},
 		{ReferenceObject: &appsv1.DaemonSet{}, EmbedFsPath: "assets/cloud-node-manager-daemonset.yaml"},
+		{ReferenceObject: &rbacv1.Role{}, EmbedFsPath: "assets/azure-cloud-provider-role.yaml"},
+		{ReferenceObject: &rbacv1.RoleBinding{}, EmbedFsPath: "assets/azure-cloud-provider-rolebinding.yaml"},
 	}
 )
 

--- a/pkg/cloud/azurestack/azurestack_test.go
+++ b/pkg/cloud/azurestack/azurestack_test.go
@@ -68,7 +68,7 @@ func TestResourcesRenderingSmoke(t *testing.T) {
 			}
 
 			resources := assets.GetRenderedResources()
-			assert.Len(t, resources, 2)
+			assert.Len(t, resources, 4)
 		})
 	}
 }

--- a/pkg/cloud/cloud_test.go
+++ b/pkg/cloud/cloud_test.go
@@ -187,20 +187,24 @@ func TestGetResources(t *testing.T) {
 	}, {
 		name:                  "Azure Stack resources returned as expected",
 		testPlatform:          platformsMap["AzureStackHub"],
-		expectedResourceCount: 3,
+		expectedResourceCount: 5,
 		expectedResourcesKindName: []string{
 			"Deployment/azure-cloud-controller-manager",
 			"DaemonSet/azure-cloud-node-manager",
+			"Role/azure-cloud-provider",
+			"RoleBinding/azure-cloud-provider:azure-cloud-provider",
 			"PodDisruptionBudget/azure-cloud-controller-manager",
 		},
 	}, {
 		name:                  "Azure Stack resources returned as expected with single node",
 		testPlatform:          platformsMap["AzureStackHub"],
-		expectedResourceCount: 2,
+		expectedResourceCount: 4,
 		singleReplica:         true,
 		expectedResourcesKindName: []string{
 			"Deployment/azure-cloud-controller-manager",
 			"DaemonSet/azure-cloud-node-manager",
+			"Role/azure-cloud-provider",
+			"RoleBinding/azure-cloud-provider:azure-cloud-provider",
 		},
 	}, {
 		name:                  "VSphere resources returned as expected",


### PR DESCRIPTION
This role was only added to Azure as a result cloud provider on AzureStackHub started failing due to not being able to acquire the lease.

This PR copies the role to be included on ASH as well.