### PR TITLE
OCPCLOUD-2978: add deny all network policy

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_10_networkpolicy-default-deny.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_10_networkpolicy-default-deny.yaml
@@ -1,0 +1,32 @@
+# Default deny all ingress and egress traffic by default in this namespace
+# At the moment no other Network Policy should be needed:
+# - CCCMO & CCM pods are host-networked Pods, so they are not affected by network policies
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-cloud-controller-manager-operator
+  annotations:
+    capability.openshift.io/name: CloudControllerManager
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-cloud-controller-manager
+  annotations:
+    capability.openshift.io/name: CloudControllerManager
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
CCM is using hostNetwork: true, so most NetworkPolicy functionality does not apply to it [OCPSTRAT-176](https://issues.redhat.com/browse/OCPSTRAT-176) only need to add one default deny all policy.

```
$ oc get deploy -n openshift-cloud-controller-manager-operator -o yaml | grep hostNetwork  
        hostNetwork: true
$ oc get deploy -n openshift-cloud-controller-manager -o yaml | grep hostNetwork  
        hostNetwork: true
```