### PR TITLE
OCPBUGS-53300: Update service selector to match deployment label

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_05_metrics-service.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_05_metrics-service.yaml
@@ -18,5 +18,5 @@ spec:
     port: 9258
     targetPort: https
   selector:
-    app: cloud-manager-operator
+    k8s-app: cloud-manager-operator
   sessionAffinity: None


### PR DESCRIPTION
Changed the service's selector label to `k8s-app=cloud-manager-operator` to ensure it matches the deployment’s [template label](https://github.com/openshift/cluster-cloud-controller-manager-operator/blob/5fc7a51c0cd1955c8e450a11a58d65b4823aa6a5/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml#L25). This enables the service to correctly discover the pod and creates an EndpointSlice for port 9258, which is necessary for proper documentation created by the communication matrix (see further explanation described in the opened [bug](https://issues.redhat.com/browse/OCPBUGS-53300))