### PR TITLE
SPLAT-2341: Add feature gate support in the cloud-config sync controller

### DIFF
--- a/pkg/cloud/aws/aws_config_transformer.go
+++ b/pkg/cloud/aws/aws_config_transformer.go
@@ -11,6 +11,8 @@ import (
 	"gopkg.in/ini.v1"
 
 	awsconfig "k8s.io/cloud-provider-aws/pkg/providers/v1/config"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 // defaultConfig is a string holding the absolute bare minimum INI string that the AWS CCM needs to start.
@@ -20,7 +22,7 @@ const defaultConfig = `[Global]
 
 // CloudConfigTransformer is used to inject OpenShift configuration defaults into the Cloud Provider config
 // for the AWS Cloud Provider. If an empty source string is provided, a minimal default configuration will be created.
-func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error) {
+func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network, features featuregates.FeatureGate) (string, error) {
 	cfg, err := readAWSConfig(source)
 	if err != nil {
 		return "", fmt.Errorf("failed to read the cloud.conf: %w", err)

--- a/pkg/cloud/aws/aws_config_transformer_test.go
+++ b/pkg/cloud/aws/aws_config_transformer_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	. "github.com/onsi/gomega"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 func TestCloudConfigTransformer(t *testing.T) {
@@ -87,7 +89,7 @@ SigningRegion = signing_region
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
 
-			gotConfig, err := CloudConfigTransformer(tc.source, nil, nil) // No Infra or Network are required for the current functionality.
+			gotConfig, err := CloudConfigTransformer(tc.source, nil, nil, featuregates.NewFeatureGate(nil, nil)) // No Infra or Network are required for the current functionality.
 			g.Expect(err).ToNot(HaveOccurred())
 
 			g.Expect(gotConfig).To(Equal(tc.expected))

--- a/pkg/cloud/azure/azure.go
+++ b/pkg/cloud/azure/azure.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/common"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 const providerName = "azure"
@@ -136,7 +137,7 @@ func IsAzure(infra *configv1.Infrastructure) bool {
 	return false
 }
 
-func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error) {
+func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network, features featuregates.FeatureGate) (string, error) {
 	if !IsAzure(infra) {
 		return "", fmt.Errorf("invalid platform, expected CloudName to be %s", configv1.AzurePublicCloud)
 	}

--- a/pkg/cloud/azure/azure_test.go
+++ b/pkg/cloud/azure/azure_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/onsi/gomega/format"
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/stretchr/testify/assert"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -259,7 +260,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 			src, err := json.Marshal(tc.source)
 			g.Expect(err).NotTo(HaveOccurred(), "Marshal of source data should succeed")
 
-			actual, err := CloudConfigTransformer(string(src), tc.infra, nil)
+			actual, err := CloudConfigTransformer(string(src), tc.infra, nil, featuregates.NewFeatureGate(nil, nil))
 			if tc.errMsg != "" {
 				g.Expect(err).Should(MatchError(tc.errMsg))
 				g.Expect(actual).Should(Equal(""))

--- a/pkg/cloud/azurestack/azurestack.go
+++ b/pkg/cloud/azurestack/azurestack.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/common"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 const providerName = "azurestack"
@@ -104,7 +105,7 @@ func IsAzureStackHub(platformStatus *configv1.PlatformStatus) bool {
 // modifies it to be compatible with the external cloud provider. It returns
 // an error if the platform is not OpenStackPlatformType or if any errors are
 // encountered while attempting to rework the configuration.
-func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error) {
+func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network, features featuregates.FeatureGate) (string, error) {
 	if !IsAzureStackHub(infra.Status.PlatformStatus) {
 		return "", fmt.Errorf("invalid platform, expected CloudName to be %s", configv1.AzureStackCloud)
 	}

--- a/pkg/cloud/azurestack/azurestack_test.go
+++ b/pkg/cloud/azurestack/azurestack_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 const (
@@ -144,7 +145,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 			src, err := json.Marshal(tc.source)
 			g.Expect(err).NotTo(HaveOccurred(), "Marshal of source data should succeed")
 
-			actual, err := CloudConfigTransformer(string(src), tc.infra, nil)
+			actual, err := CloudConfigTransformer(string(src), tc.infra, nil, featuregates.NewFeatureGate(nil, nil))
 			if tc.errMsg != "" {
 				g.Expect(err).Should(MatchError(tc.errMsg))
 				g.Expect(actual).Should(Equal(""))

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/common"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/aws"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/azure"
@@ -23,7 +24,7 @@ import (
 // cloudConfigTransformer function transforms the source config map using the input infrastructure.config.openshift.io
 // and network.config.openshift.io objects. Only the data and binaryData field of the output ConfigMap will be respected by
 // consumer of the transformer.
-type cloudConfigTransformer func(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error)
+type cloudConfigTransformer func(source string, infra *configv1.Infrastructure, network *configv1.Network, features featuregates.FeatureGate) (string, error)
 
 // GetCloudConfigTransformer returns the function that should be used to transform
 // the cloud configuration config map, and a boolean to indicate if the config should

--- a/pkg/cloud/common/config.go
+++ b/pkg/cloud/common/config.go
@@ -2,10 +2,12 @@ package common
 
 import (
 	configv1 "github.com/openshift/api/config/v1"
+
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 // NoOpTransformer implements the cloudConfigTransformer. It makes no changes
 // to the source configuration and simply returns it as-is.
-func NoOpTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error) {
+func NoOpTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network, features featuregates.FeatureGate) (string, error) {
 	return source, nil
 }

--- a/pkg/cloud/openstack/openstack.go
+++ b/pkg/cloud/openstack/openstack.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/common"
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 const providerName = "openstack"
@@ -142,7 +143,7 @@ func NewProviderAssets(config config.OperatorConfig) (common.CloudProviderAssets
 // modifies it to be compatible with the external cloud provider. It returns
 // an error if the platform is not OpenStackPlatformType or if any errors are
 // encountered while attempting to rework the configuration.
-func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error) {
+func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network, features featuregates.FeatureGate) (string, error) {
 	if infra.Status.PlatformStatus == nil ||
 		infra.Status.PlatformStatus.Type != configv1.OpenStackPlatformType {
 		return "", fmt.Errorf("invalid platform, expected to be %s", configv1.OpenStackPlatformType)

--- a/pkg/cloud/openstack/openstack_test.go
+++ b/pkg/cloud/openstack/openstack_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 const (
@@ -172,7 +173,7 @@ use-octavia            = false
 	for _, tc := range tc {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			actual, err := CloudConfigTransformer(tc.source, tc.infra, tc.network)
+			actual, err := CloudConfigTransformer(tc.source, tc.infra, tc.network, featuregates.NewFeatureGate(nil, nil))
 			if tc.errMsg != "" {
 				g.Expect(err).Should(MatchError(tc.errMsg))
 				return

--- a/pkg/cloud/vsphere/vsphere_config_transformer.go
+++ b/pkg/cloud/vsphere/vsphere_config_transformer.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/utils/net"
 
 	ccmConfig "github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud/vsphere/vsphere_cloud_config"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
 // Well-known OCP-specific vSphere tags. These values are going to the "labels" sections in CCM cloud-config.
@@ -27,7 +28,7 @@ const (
 // Currently, CloudConfigTransformer is responsible to populate vcenters, labels, and node networking parameters from
 // the Infrastructure resource.
 // Also, this function converts legacy deprecated INI configuration format to a YAML-based one.
-func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error) {
+func CloudConfigTransformer(source string, infra *configv1.Infrastructure, network *configv1.Network, features featuregates.FeatureGate) (string, error) {
 	if infra.Status.PlatformStatus == nil ||
 		infra.Status.PlatformStatus.Type != configv1.VSpherePlatformType {
 		return "", fmt.Errorf("invalid platform, expected to be %s", configv1.VSpherePlatformType)


### PR DESCRIPTION
Introducing feature gate support to the cloudConfigTransformer of cloud-config sync controller, so we can ensure custom configuration depending of OCP feature gate.

The idea is to provide the interface to enable the CCM feature of default SG provisioning on NLBs, [SPLAT-2137](https://issues.redhat.com/browse/SPLAT-2137).

The feature gate will added to providers in follow up PRs, starting to AWS config transformer: https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/391/commits/c61b48dc1c87ad42b810b764743ca87e692c3e3f , related to https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/391
```diff
-func setOpenShiftDefaults(cfg *awsconfig.CloudConfig) {
+func setOpenShiftDefaults(cfg *awsconfig.CloudConfig, features featuregates.FeatureGate) {
	if cfg.Global.ClusterServiceLoadBalancerHealthProbeMode == "" {
		// OpenShift uses Shared mode by default.
		// This attaches the health check for Cluster scope services to the "kube-proxy"
		// health check endpoint served by OVN.
		cfg.Global.ClusterServiceLoadBalancerHealthProbeMode = "Shared"
	}
+	if features.Enabled("AWSServiceLBNetworkSecurityGroup") {
+		if cfg.Global.NLBSecurityGroupMode != awsconfig.NLBSecurityGroupModeManaged {
+			// OpenShift enforces security group by default when deploying
+			// service type loadbalancer NLB.
+			cfg.Global.NLBSecurityGroupMode = awsconfig.NLBSecurityGroupModeManaged
+		}
+	}

}
```

Ref: [SPLAT-2341](https://issues.redhat.com/browse/SPLAT-2341)
