### PR TITLE
OCPBUGS-59251: Default cloud.conf if no configmap is found

### DIFF
--- a/pkg/cloud/aws/aws_config_transformer.go
+++ b/pkg/cloud/aws/aws_config_transformer.go
@@ -13,6 +13,8 @@ import (
 	awsconfig "k8s.io/cloud-provider-aws/pkg/providers/v1/config"
 )
 
+// defaultConfig is a string holding the absolute bare minimum INI string that the AWS CCM needs to start.
+// The value will be further customized for OCP in the CloudConfigTransformer.
 const defaultConfig = `[Global]
 `
 

--- a/pkg/cloud/aws/aws_config_transformer_test.go
+++ b/pkg/cloud/aws/aws_config_transformer_test.go
@@ -13,9 +13,18 @@ func TestCloudConfigTransformer(t *testing.T) {
 		expected string
 	}{
 		{
-			name: "empty source",
+			name: "default source",
 			source: `[Global]
 			`, // This is the default that gets created for any OpenShift Cluster.
+			expected: `[Global]
+DisableSecurityGroupIngress                     = false
+ClusterServiceLoadBalancerHealthProbeMode       = Shared
+ClusterServiceSharedLoadBalancerHealthProbePort = 0
+`,
+		},
+		{
+			name:   "completely empty source",
+			source: "", // This could happen in cases where the cluster was born prior to a cloud.conf being required.
 			expected: `[Global]
 DisableSecurityGroupIngress                     = false
 ClusterServiceLoadBalancerHealthProbeMode       = Shared

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -25,10 +25,6 @@ import (
 // consumer of the transformer.
 type cloudConfigTransformer func(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error)
 
-// defaultCloudConfig returns a default cloud configuration in the event that a cluster does not have a source config map.
-// Clusters created prior to 4.14 do not always have a source config map.
-type defaultCloudConfig func(platform configv1.PlatformType) (string, error)
-
 // GetCloudConfigTransformer returns the function that should be used to transform
 // the cloud configuration config map, and a boolean to indicate if the config should
 // be synced from the CCO namespace before applying the transformation.

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -25,6 +25,10 @@ import (
 // consumer of the transformer.
 type cloudConfigTransformer func(source string, infra *configv1.Infrastructure, network *configv1.Network) (string, error)
 
+// defaultCloudConfig returns a default cloud configuration in the event that a cluster does not have a source config map.
+// Clusters created prior to 4.14 do not always have a source config map.
+type defaultCloudConfig func(platform configv1.PlatformType) (string, error)
+
 // GetCloudConfigTransformer returns the function that should be used to transform
 // the cloud configuration config map, and a boolean to indicate if the config should
 // be synced from the CCO namespace before applying the transformation.

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -28,6 +28,8 @@ const (
 	infraCloudConfKey  = "foo"
 
 	defaultAzureConfig = `{"cloud":"AzurePublicCloud","tenantId":"0000000-0000-0000-0000-000000000000","Entries":null,"subscriptionId":"0000000-0000-0000-0000-000000000000","vmType":"standard","putVMSSVMBatchSize":0,"enableMigrateToIPBasedBackendPoolAPI":false,"clusterServiceLoadBalancerHealthProbeMode":"shared"}`
+	defaultAWSConfig   = `[Global]
+`
 )
 
 func makeInfrastructureResource(platform configv1.PlatformType) *configv1.Infrastructure {
@@ -84,8 +86,7 @@ func makeInfraStatus(platform configv1.PlatformType) configv1.InfrastructureStat
 }
 
 func makeInfraCloudConfig(platform configv1.PlatformType) *corev1.ConfigMap {
-	defaultConfig := `[Global]
-`
+	defaultConfig := defaultAWSConfig
 
 	if platform == configv1.AzurePlatformType {
 		defaultConfig = defaultAzureConfig
@@ -98,8 +99,7 @@ func makeInfraCloudConfig(platform configv1.PlatformType) *corev1.ConfigMap {
 }
 
 func makeManagedCloudConfig(platform configv1.PlatformType) *corev1.ConfigMap {
-	defaultConfig := `[Global]
-`
+	defaultConfig := defaultAWSConfig
 
 	if platform == configv1.AzurePlatformType {
 		defaultConfig = defaultAzureConfig
@@ -149,14 +149,6 @@ var _ = Describe("prepareSourceConfigMap reconciler method", func() {
 		_, ok = preparedConfig.Data[defaultConfigKey]
 		Expect(ok).Should(BeTrue())
 		Expect(reconciler.isCloudConfigEqual(preparedConfig, managedCloudConfig)).Should(BeTrue())
-	})
-
-	It("config preparation should fail if key from infra resource does not found", func() {
-		brokenInfraConfig := infraCloudConfig.DeepCopy()
-		brokenInfraConfig.Data = map[string]string{"hehehehehe": "bar"}
-		_, err := reconciler.prepareSourceConfigMap(brokenInfraConfig, infra)
-		Expect(err).Should(Not(Succeed()))
-		Expect(err.Error()).Should(BeEquivalentTo("key foo specified in infra resource does not found in source configmap openshift-config/test-config"))
 	})
 
 	It("config preparation should not touch extra fields in infra ConfigMap", func() {
@@ -467,7 +459,7 @@ var _ = Describe("Cloud config sync reconciler", func() {
 			Expect(cl.Create(ctx, makeInfraCloudConfig(configv1.AWSPlatformType))).To(Succeed())
 		})
 
-		It("should skip config sync for AWS platform if there is no reference in infra resource", func() {
+		It("should sync a default config AWS platform if there is no reference in infra resource", func() {
 			infraResource := makeInfrastructureResource(configv1.AWSPlatformType)
 			infraResource.Spec.CloudConfig.Name = ""
 			Expect(cl.Create(ctx, infraResource)).To(Succeed())
@@ -475,13 +467,20 @@ var _ = Describe("Cloud config sync reconciler", func() {
 			infraResource.Status = makeInfraStatus(infraResource.Spec.PlatformSpec.Type)
 			Expect(cl.Status().Update(ctx, infraResource.DeepCopy())).To(Succeed())
 
+			fetchedResource := &configv1.Infrastructure{}
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(infraResource), fetchedResource)).To(Succeed())
+			Expect(fetchedResource.Spec.CloudConfig.Name).To(Equal(""))
+
 			_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{})
 			Expect(err).To(BeNil())
 
 			allCMs := &corev1.ConfigMapList{}
 			Expect(cl.List(ctx, allCMs, &client.ListOptions{Namespace: targetNamespaceName})).To(Succeed())
 
-			Expect(len(allCMs.Items)).To(BeZero())
+			Expect(len(allCMs.Items)).To(BeEquivalentTo(1))
+			// Our code ensures that there is at a minimum a global section.
+			// The CCM itself may end up defaulting values for us, so don't use exact string matching.
+			Expect(allCMs.Items[0].Data[defaultConfigKey]).To(HavePrefix(defaultAWSConfig))
 		})
 
 		It("should perform config sync for AWS platform if there is a reference in infra resource", func() {
@@ -499,6 +498,19 @@ var _ = Describe("Cloud config sync reconciler", func() {
 
 			Expect(len(allCMs.Items)).NotTo(BeZero())
 			Expect(len(allCMs.Items)).To(BeEquivalentTo(1))
+		})
+
+		It("should error if a user-specified configmap key isn't present", func() {
+			infraResource := makeInfrastructureResource(configv1.AWSPlatformType)
+			infraResource.Spec.CloudConfig.Key = "notfound"
+			Expect(cl.Create(ctx, infraResource)).To(Succeed())
+
+			infraResource.Status = makeInfraStatus(infraResource.Spec.PlatformSpec.Type)
+			Expect(cl.Status().Update(ctx, infraResource.DeepCopy())).To(Succeed())
+
+			_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{})
+			Expect(err).To(Not(BeNil()))
+
 		})
 	})
 

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -462,6 +462,7 @@ var _ = Describe("Cloud config sync reconciler", func() {
 		It("should sync a default config AWS platform if there is no reference in infra resource", func() {
 			infraResource := makeInfrastructureResource(configv1.AWSPlatformType)
 			infraResource.Spec.CloudConfig.Name = ""
+			infraResource.Spec.CloudConfig.Key = ""
 			Expect(cl.Create(ctx, infraResource)).To(Succeed())
 
 			infraResource.Status = makeInfraStatus(infraResource.Spec.PlatformSpec.Type)
@@ -509,7 +510,7 @@ var _ = Describe("Cloud config sync reconciler", func() {
 			Expect(cl.Status().Update(ctx, infraResource.DeepCopy())).To(Succeed())
 
 			_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{})
-			Expect(err).To(Not(BeNil()))
+			Expect(err.Error()).To(ContainSubstring("specified in infra resource does not exist in source configmap"))
 
 		})
 	})


### PR DESCRIPTION
Prior to 4.14, OCP's installer did not provide any cloud configuration in the `Infrastructure` resource. This was ok because nothing relied on it.

However in 4.19, we introduced a hard requirement for the cloud configuration on AWS.

This change allows us to gracefully handle missing information in `Infrastructure` by providing a minimal default `cloud.conf` on AWS.