### PR TITLE
OCPBUGS-51305: ccm: disable unused secure-serving port and webhook

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -43,6 +43,7 @@ spec:
           --leader-elect-renew-deadline=107s \
           --leader-elect-retry-period=26s \
           --leader-elect-resource-namespace=openshift-cloud-controller-manager \
+          --secure-port=0 \
           -v=2
         env:
         - name: CLOUD_CONFIG

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -121,7 +121,8 @@ spec:
                 --leader-elect-lease-duration=137s \
                 --leader-elect-renew-deadline=107s \
                 --leader-elect-retry-period=26s \
-                --leader-elect-resource-namespace=openshift-cloud-controller-manager
+                --leader-elect-resource-namespace=openshift-cloud-controller-manager \
+                --secure-port=0
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -113,7 +113,8 @@ spec:
                 --leader-elect-lease-duration=137s \
                 --leader-elect-renew-deadline=107s \
                 --leader-elect-retry-period=26s \
-                --leader-elect-resource-namespace=openshift-cloud-controller-manager
+                --leader-elect-resource-namespace=openshift-cloud-controller-manager \
+                --secure-port=0
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
+++ b/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
@@ -95,7 +95,8 @@ spec:
                 --leader-elect-lease-duration=137s \
                 --leader-elect-renew-deadline=107s \
                 --leader-elect-retry-period=26s \
-                --leader-elect-resource-namespace=openshift-cloud-controller-manager
+                --leader-elect-resource-namespace=openshift-cloud-controller-manager \
+                --secure-port=0
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/nutanix/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/nutanix/assets/cloud-controller-manager-deployment.yaml
@@ -98,7 +98,8 @@ spec:
                 --leader-elect-renew-deadline=107s \
                 --leader-elect-retry-period=26s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager \
-                --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+                --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 \
+                --secure-port=0
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: nutanix-config

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -78,7 +78,8 @@ spec:
             --leader-elect-renew-deadline=107s \
             --leader-elect-retry-period=26s \
             --leader-elect-resource-namespace=openshift-cloud-controller-manager \
-            --feature-gates={{ .featureGates }}
+            --feature-gates={{ .featureGates }} \
+            --secure-port=0
           ports:
           - containerPort: 10258
             name: https

--- a/pkg/cloud/vsphere/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/vsphere/assets/cloud-controller-manager-deployment.yaml
@@ -99,7 +99,8 @@ spec:
                 --leader-elect-retry-period=26s \
                 --leader-elect-resource-namespace=openshift-cloud-controller-manager \
                 --feature-gates={{ .featureGates }} \
-                --use-service-account-credentials=true
+                --use-service-account-credentials=true \
+                --secure-port=0
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: host-etc-kube


### PR DESCRIPTION
Disables the secure-serving port which is unused for all providers, except ibm and powervs where it is used as livenessprobe.