### PR TITLE
OCPBUGS-60385: Add Microsoft.Network/publicIPAddresses/delete permission

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
@@ -32,6 +32,7 @@ spec:
     - Microsoft.Network/privatelinkservices/delete
     - Microsoft.Network/privatelinkservices/read
     - Microsoft.Network/privatelinkservices/write
+    - Microsoft.Network/publicIPAddresses/delete
     - Microsoft.Network/publicIPAddresses/join/action
     - Microsoft.Network/publicIPAddresses/read
     - Microsoft.Network/publicIPAddresses/write


### PR DESCRIPTION
This permission is required for the DeletePublicIP function in the
Azure Cloud Controller Manager to properly clean up orphaned public IP
addresses when LoadBalancer services are deleted.

Code location:
- File: pkg/provider/azure_publicip_repo.go:81
- Function: DeletePublicIP
- API call: NetworkClientFactory.GetPublicIPAddressClient().Delete()