### PR TITLE
OCPBUGS-54490: Add Azure permissions for Private Link Service operations

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
@@ -20,16 +20,26 @@ spec:
     - Microsoft.Network/loadBalancers/read
     - Microsoft.Network/loadBalancers/write
     - Microsoft.Network/loadBalancers/inboundNatRules/join/action
+    - Microsoft.Network/loadBalancers/loadBalancingRules/read
+    - Microsoft.Network/natGateways/join/action
+    - Microsoft.Network/networkIntentPolicies/join/action
     - Microsoft.Network/networkInterfaces/read
     - Microsoft.Network/networkInterfaces/write
+    - Microsoft.Network/networkManagers/ipamPools/associateResourcesToPool/action
     - Microsoft.Network/networkSecurityGroups/read
     - Microsoft.Network/networkSecurityGroups/write
     - Microsoft.Network/networkSecurityGroups/join/action
+    - Microsoft.Network/privatelinkservices/delete
+    - Microsoft.Network/privatelinkservices/read
+    - Microsoft.Network/privatelinkservices/write
     - Microsoft.Network/publicIPAddresses/join/action
     - Microsoft.Network/publicIPAddresses/read
     - Microsoft.Network/publicIPAddresses/write
+    - Microsoft.Network/routeTables/join/action
+    - Microsoft.Network/serviceEndpointPolicies/join/action
     - Microsoft.Network/virtualNetworks/subnets/join/action
     - Microsoft.Network/virtualNetworks/subnets/read
+    - Microsoft.Network/virtualNetworks/subnets/write
     - Microsoft.Network/publicIPPrefixes/join/action
     - Microsoft.Network/applicationSecurityGroups/joinNetworkSecurityRule/action
   serviceAccountNames:


### PR DESCRIPTION
This PR adds missing permissions related to Private Link Service.

1. Microsoft.Network/privatelinkservices/write
   - Code: pkg/provider/privatelinkservice/repo.go:93
   - API: client.CreateOrUpdate(ctx, resourceGroup, *pls.Name, pls)

2. Microsoft.Network/privatelinkservices/read
   - Code: Various PLS Get operations and cache management

3. Microsoft.Network/privatelinkservices/delete
   - Code: pkg/provider/privatelinkservice/repo.go:109
   - API: client.Delete(ctx, resourceGroup, plsName)

4. Microsoft.Network/virtualNetworks/subnets/write
   - Code: pkg/provider/azure_privatelinkservice.go:232
   - API: subnetRepo.CreateOrUpdate(ctx, rg, vnetName, subnetName, subnet)
   - Purpose: Disable PrivateLinkServiceNetworkPolicies on subnet

5. Microsoft.Network/loadBalancers/loadBalancingRules/read
   - Required for Azure internal validation when PLS references
     LoadBalancerFrontendIPConfigurations

**Additional Join Permissions:**
When modifying subnets, Azure requires join permissions
for networking resources that may be associated with the subnet:

6. Microsoft.Network/serviceEndpointPolicies/join/action
7. Microsoft.Network/natGateways/join/action
8. Microsoft.Network/networkIntentPolicies/join/action
9. Microsoft.Network/networkSecurityGroups/join/action
10. Microsoft.Network/routeTables/join/action
11. Microsoft.Network/networkManagers/ipamPools/associateResourcesToPool/action

These are not direct API calls from cloud-provider code, but Azure ARM
requirements when subnet modifications might affect associated resources.