### PR TITLE
OCPBUGS-65469: Add all managed resources to ClusterOperator relatedObjects

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_12_clusteroperator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_12_clusteroperator.yaml
@@ -22,3 +22,6 @@ status:
     - group: ""
       name: openshift-cloud-controller-manager-operator
       resource: namespaces
+    - group: rbac.authorization.k8s.io
+      name: cloud-controller-manager
+      resource: clusterroles

--- a/pkg/controllers/status.go
+++ b/pkg/controllers/status.go
@@ -207,6 +207,7 @@ func (r *ClusterOperatorStatusClient) relatedObjects() []configv1.ObjectReferenc
 		{Resource: "namespaces", Name: defaultManagementNamespace},
 		{Group: configv1.GroupName, Resource: "clusteroperators", Name: clusterOperatorName},
 		{Resource: "namespaces", Name: r.ManagedNamespace},
+		{Group: "rbac.authorization.k8s.io", Resource: "clusterroles", Name: clusterOperatorName},
 	}
 }
 


### PR DESCRIPTION
Adds all resources managed by the cloud-controller-manager operator to the ClusterOperator's relatedObjects list, ensuring `oc adm inspect` and must-gather collect the complete set of resources needed for debugging.

## Resources added
- ConfigMaps (cloud-controller-manager-images, kube-rbac-proxy)
- Services, Deployments
- NetworkPolicies
- ServiceAccounts
- Roles and RoleBindings (operator, openshift-config, openshift-config-managed, kube-system namespaces)
- ClusterRoles and ClusterRoleBindings (operator, cloud-node-manager, openstack-cloud-controller-manager)
- CredentialsRequests (Azure, GCP, IBM, Nutanix, OpenStack, PowerVS, vSphere)

Also fixes the namespace ordering to list the operator namespace before the managed namespace.

Both the static manifest YAML and the Go source are kept in sync.