### PR TITLE
OCPCLOUD-3372: Use centralized tls profile for webhook tls

### DIFF
--- a/pkg/cloud/aws/assets/deployment.yaml
+++ b/pkg/cloud/aws/assets/deployment.yaml
@@ -42,6 +42,8 @@ spec:
           --leader-elect-lease-duration=137s \
           --leader-elect-renew-deadline=107s \
           --leader-elect-retry-period=26s \
+          --webhooks=* \
+          --feature-gates=CloudControllerManagerWebhook=true \
           --leader-elect-resource-namespace=openshift-cloud-controller-manager \
           {{- if .tlsCipherSuites }}
           --tls-cipher-suites={{ .tlsCipherSuites }} \
@@ -49,7 +51,12 @@ spec:
           {{- if .tlsMinVersion }}
           --tls-min-version={{ .tlsMinVersion }} \
           {{- end }}
-          --secure-port=0 \
+          {{- if .tlsCipherSuites }}
+          --webhook-tls-cipher-suites={{ .tlsCipherSuites }} \
+          {{- end }}
+          {{- if .tlsMinVersion }}
+          --webhook-tls-min-version={{ .tlsMinVersion }} \
+          {{- end }}
           -v=2
         env:
         - name: CLOUD_CONFIG

--- a/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azure/assets/cloud-controller-manager-deployment.yaml
@@ -128,7 +128,12 @@ spec:
                 {{- if .tlsMinVersion }}
                 --tls-min-version={{ .tlsMinVersion }} \
                 {{- end }}
-                --secure-port=0
+                {{- if .tlsCipherSuites }}
+                --webhook-tls-cipher-suites={{ .tlsCipherSuites }} \
+                {{- end }}
+                {{- if .tlsMinVersion }}
+                --webhook-tls-min-version={{ .tlsMinVersion }}
+                {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/azurestack/assets/cloud-controller-manager-deployment.yaml
@@ -120,7 +120,12 @@ spec:
                 {{- if .tlsMinVersion }}
                 --tls-min-version={{ .tlsMinVersion }} \
                 {{- end }}
-                --secure-port=0
+                {{- if .tlsCipherSuites }}
+                --webhook-tls-cipher-suites={{ .tlsCipherSuites }} \
+                {{- end }}
+                {{- if .tlsMinVersion }}
+                --webhook-tls-min-version={{ .tlsMinVersion }}
+                {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
+++ b/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
@@ -102,7 +102,12 @@ spec:
                 {{- if .tlsMinVersion }}
                 --tls-min-version={{ .tlsMinVersion }} \
                 {{- end }}
-                --secure-port=0
+                {{- if .tlsCipherSuites }}
+                --webhook-tls-cipher-suites={{ .tlsCipherSuites }} \
+                {{- end }}
+                {{- if .tlsMinVersion }}
+                --webhook-tls-min-version={{ .tlsMinVersion }}
+                {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: host-etc-kube

--- a/pkg/cloud/ibm/assets/deployment.yaml
+++ b/pkg/cloud/ibm/assets/deployment.yaml
@@ -90,6 +90,12 @@ spec:
             {{- if .tlsMinVersion }}
             --tls-min-version={{ .tlsMinVersion }} \
             {{- end }}
+            {{- if .tlsCipherSuites }}
+            --webhook-tls-cipher-suites={{ .tlsCipherSuites }} \
+            {{- end }}
+            {{- if .tlsMinVersion }}
+            --webhook-tls-min-version={{ .tlsMinVersion }} \
+            {{- end }}
             --v=2
         livenessProbe:
           failureThreshold: 3

--- a/pkg/cloud/nutanix/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/nutanix/assets/cloud-controller-manager-deployment.yaml
@@ -104,7 +104,12 @@ spec:
                 {{- if .tlsMinVersion }}
                 --tls-min-version={{ .tlsMinVersion }} \
                 {{- end }}
-                --secure-port=0
+                {{- if .tlsCipherSuites }}
+                --webhook-tls-cipher-suites={{ .tlsCipherSuites }} \
+                {{- end }}
+                {{- if .tlsMinVersion }}
+                --webhook-tls-min-version={{ .tlsMinVersion }}
+                {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: nutanix-config

--- a/pkg/cloud/openstack/assets/deployment.yaml
+++ b/pkg/cloud/openstack/assets/deployment.yaml
@@ -85,7 +85,12 @@ spec:
             {{- if .tlsMinVersion }}
             --tls-min-version={{ .tlsMinVersion }} \
             {{- end }}
-            --secure-port=0
+            {{- if .tlsCipherSuites }}
+            --webhook-tls-cipher-suites={{ .tlsCipherSuites }} \
+            {{- end }}
+            {{- if .tlsMinVersion }}
+            --webhook-tls-min-version={{ .tlsMinVersion }}
+            {{- end }}
           ports:
           - containerPort: 10258
             name: https

--- a/pkg/cloud/powervs/assets/deployment.yaml
+++ b/pkg/cloud/powervs/assets/deployment.yaml
@@ -89,6 +89,12 @@ spec:
             {{- if .tlsMinVersion }}
             --tls-min-version={{ .tlsMinVersion }} \
             {{- end }}
+            {{- if .tlsCipherSuites }}
+            --webhook-tls-cipher-suites={{ .tlsCipherSuites }} \
+            {{- end }}
+            {{- if .tlsMinVersion }}
+            --webhook-tls-min-version={{ .tlsMinVersion }} \
+            {{- end }}
             --v=2
         livenessProbe:
           httpGet:

--- a/pkg/cloud/vsphere/assets/cloud-controller-manager-deployment.yaml
+++ b/pkg/cloud/vsphere/assets/cloud-controller-manager-deployment.yaml
@@ -111,7 +111,12 @@ spec:
                 {{- if .tlsMinVersion }}
                 --tls-min-version={{ .tlsMinVersion }} \
                 {{- end }}
-                --secure-port=0
+                {{- if .tlsCipherSuites }}
+                --webhook-tls-cipher-suites={{ .tlsCipherSuites }} \
+                {{- end }}
+                {{- if .tlsMinVersion }}
+                --webhook-tls-min-version={{ .tlsMinVersion }}
+                {{- end }}
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - name: host-etc-kube


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled webhook support for the AWS cloud controller manager.
  * Added configurable webhook TLS cipher suites and minimum TLS versions across supported cloud providers.
* **Security**
  * Webhook servers now honor configured TLS settings, allowing deployments to enforce stronger encryption requirements.
* **Improvements**
  * Updated cloud controller manager deployments to use webhook-specific secure communication settings instead of the previous disabled secure-port configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->