### PR TITLE
NO-JIRA: fix: report all degraded controller conditions instead of first only#444

### DIFF
--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -19,6 +19,8 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
@@ -302,11 +304,12 @@ func (r *CloudOperatorReconciler) checkControllerConditions(ctx context.Context)
 
 	cloudConfigControllerAvailable := false
 	trustedCABundleControllerAvailable := false
+	var degradedMessages []string
 
 	for _, cond := range co.Status.Conditions {
 		if cond.Type == cloudConfigControllerDegradedCondition || cond.Type == trustedCABundleControllerDegradedCondition {
 			if cond.Status == configv1.ConditionTrue {
-				return false, fmt.Errorf("failed to apply resources because %s condition is set to True: %s", cond.Type, cond.Message)
+				degradedMessages = append(degradedMessages, fmt.Sprintf("%s condition is set to True: %s", cond.Type, cond.Message))
 			}
 		}
 
@@ -317,6 +320,11 @@ func (r *CloudOperatorReconciler) checkControllerConditions(ctx context.Context)
 		if cond.Type == trustedCABundleControllerAvailableCondition && cond.Status == configv1.ConditionTrue {
 			trustedCABundleControllerAvailable = true
 		}
+	}
+
+	if len(degradedMessages) > 0 {
+		sort.Strings(degradedMessages)
+		return false, fmt.Errorf("failed to apply resources because %s", strings.Join(degradedMessages, "; "))
 	}
 
 	return cloudConfigControllerAvailable && trustedCABundleControllerAvailable, nil


### PR DESCRIPTION
## Summary

- `checkControllerConditions()` was iterating the CO status conditions and returning early on the first degraded condition found, so when both `CloudConfigController` and `TrustedCABundleController` are degraded simultaneously, only one gets reflected in the operator's `Degraded` status message — whichever happens to appear first in the slice.
- This caused a flake in the e2e test for [OCP-70566 (openshift/openshift-tests-private#29732) ](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cloud-provider-vsphere/113/pull-ci-openshift-cloud-provider-vsphere-main-regression-clusterinfra-vsphere-ipi-ccm/2041836972019814400) where the test expected `TrustedCABundleControllerControllerDegraded` in the message but got `CloudConfigControllerDegraded` instead.

## Fix

Collect all degraded conditions in a single pass and return a combined error message, so all failing controllers are always reported.

## Test plan
- [ ] Re-run `[sig-cluster-lifecycle] Cluster_Infrastructure CCM Medium-70566-Garbage in cloud-controller-manager status` — the `Degraded` message will now contain both conditions when both controllers fail, making the test deterministic