### PR TITLE
NO-JIRA: fix: add pod annotation: openshift.io/required-scc: hostaccess

### DIFF
--- a/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
@@ -397,6 +397,24 @@ subjects:
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:openshift:scc:hostaccess:cloud-controller-manager-operator
+  annotations:
+    capability.openshift.io/name: CloudControllerManager
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:hostaccess
+subjects:
+- kind: ServiceAccount
+  namespace: openshift-cloud-controller-manager-operator
+  name: cluster-cloud-controller-manager
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: cluster-cloud-controller-manager

--- a/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
+++ b/manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         kubectl.kubernetes.io/default-container: cluster-cloud-controller-manager
+        openshift.io/required-scc: hostaccess
       labels:
         k8s-app: cloud-manager-operator
     spec:


### PR DESCRIPTION
The openshift.io/required-scc: hostaccess annotation should be set on
pods as required by the [requiredSCCAnnotationChecker](https://github.com/openshift/origin/blob/d7ad0db6b652a27b8e7d547dcca79a5e00be7d08/pkg/monitortests/authentication/requiredsccmonitortests/monitortest.go#L85-L87)

more info on scc: 
- https://github.com/openshift/openshift-docs/blob/72420d78d324c3088372ec7c508d933864181336/modules/security-context-constraints-requiring.adoc#L26
- https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/authentication_and_authorization/managing-pod-security-policies#security-context-constraints-about_configuring-internal-oauth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pod security constraint updated so scheduled pods now require the host-access SCC.
  * Operator granted the necessary binding to use the host-access SCC.
  * TLS secret mounting remains optional; no runtime behavior change.
  * Minor formatting cleanup (trailing newline) to manifest files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->