### PR TITLE
OCPCLOUD-3436: use AlwaysAllow UnhealthyPodEvictionPolicy option in PDBs

### DIFF
--- a/pkg/cloud/common/resources.go
+++ b/pkg/cloud/common/resources.go
@@ -8,6 +8,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/config"
@@ -50,7 +51,8 @@ func getPDB(config config.OperatorConfig) (*policyv1.PodDisruptionBudget, error)
 			Namespace: config.ManagedNamespace,
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
-			MinAvailable: &minAvailable,
+			MinAvailable:               &minAvailable,
+			UnhealthyPodEvictionPolicy: ptr.To(policyv1.AlwaysAllow),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: matchLabels,
 			},

--- a/pkg/controllers/resourceapply/resourceapply_test.go
+++ b/pkg/controllers/resourceapply/resourceapply_test.go
@@ -856,6 +856,17 @@ var _ = Describe("applyPodDisruptionBudget", func() {
 				expectModified: true,
 			},
 		),
+		Entry("When there is a mismatch of UnhealthyPodEvictionPolicy it is updated",
+			applyPodDisruptionBudgetArguments{
+				inputFn: podDisruptionBudget,
+				existingFn: func(namespace string) *policyv1.PodDisruptionBudget {
+					pdb := podDisruptionBudget(namespace)
+					pdb.Spec.UnhealthyPodEvictionPolicy = nil
+					return pdb
+				},
+				expectModified: true,
+			},
+		),
 	)
 })
 
@@ -1012,7 +1023,8 @@ func podDisruptionBudget(namespace string) *policyv1.PodDisruptionBudget {
 			Namespace: namespace,
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
-			MinAvailable: &minAvailable,
+			MinAvailable:               &minAvailable,
+			UnhealthyPodEvictionPolicy: ptr.To(policyv1.AlwaysAllow),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"foo": "bar"},
 			},


### PR DESCRIPTION
Allow eviction of unhealthy (not ready) pods even if there are no disruptions
allowed on a PodDisruptionBudget. This can help to drain/maintain a node and
recover without a manual intervention when multiple instances of nodes or pods
are misbehaving.

Conventions change: https://github.com/openshift/enhancements/pull/1995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PodDisruptionBudgets now explicitly set the unhealthy-pod eviction policy to always allow evictions, ensuring consistent eviction behavior during node or pod disruptions.

* **Tests**
  * Test coverage updated to include cases where existing and desired PodDisruptionBudget eviction policies differ, ensuring correct detection and apply behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->