### PR TITLE
NO-JIRA: update owners for CCM-AWS OTE path for SPLAT teeam

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,35 @@
+# See the OWNERS_ALIASES docs: https://git.k8s.io/community/contributors/guide/owners.md#owners_aliases
+
+aliases:
+  cccmo-approvers:
+  - JoelSpeed
+  - damdo
+  - elmiko
+  - mdbooth
+  - nrb
+  - racheljpg
+  - theobarberbany
+  cccmo-reviewers:
+  - RadekManak
+  - damdo
+  - mdbooth
+  - nrb
+  - racheljpg
+  - theobarberbany
+  splat-squad-aws-approvers:
+  - mtulio
+  - mfbonfigli
+  - rvanderp3
+  - jcpowermac
+  splat-squad-aws-reviewers:
+  - mtulio
+  - mfbonfigli
+  - vr4manta
+  splat-squad-vsphere-approvers:
+  - jcpowermac
+  - rvanderp3
+  - vr4manta
+  splat-squad-vsphere-reviewers:
+  - jcpowermac
+  - vr4manta
+  - rvanderp3

--- a/openshift-tests/ccm-aws-tests/OWNERS
+++ b/openshift-tests/ccm-aws-tests/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+- cccmo-approvers
+- splat-squad-aws-approvers
+reviewers:
+- cccmo-reviewers
+- splat-squad-aws-reviewers
+- miyadav

--- a/openshift-tests/operator-tests/OWNERS
+++ b/openshift-tests/operator-tests/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+- cccmo-approvers
+reviewers:
+- cccmo-reviewers
+- splat-squad-vsphere-reviewers


### PR DESCRIPTION
Add SPLAT team ownership for the OTE code parts helping support/maintaining across different variants tested on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ownership and code review configuration across multiple test directories to clarify approval workflows and team responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->