### PR TITLE
SPLAT-2792: Fixed issue where old vCenters not removed from new cloud config

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -38,9 +38,15 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/antlr/antlr4/runtime/Go/antlr/v4 v4.0.0-20230305170008-8188dc5388df/go.mod h1:pSwJ0fSY5KhvocuWSx4fz3BA8OrA1bQn+K1Eli3BRwM=
 github.com/armon/circbuf v0.0.0-20190214190532-5111143e8da2/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/aws/aws-sdk-go-v2 v1.36.4/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/aws-sdk-go-v2/config v1.29.14/go.mod h1:wVPHWcIFv3WO89w0rE10gzf17ZYy+UVS1Geq8Iei34g=
+github.com/aws/aws-sdk-go-v2/credentials v1.17.67/go.mod h1:p3C44m+cfnbv763s52gCqrjaqyPikj9Sg47kUVaNZQQ=
+github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/service/autoscaling v1.53.3/go.mod h1:6U/Xm5bBkZGCTxH3NE9+hPKEpCFCothGn/gwytsr1Mk=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.36.2/go.mod h1:lvUlMghKYmSxSfv0vU7pdU/8jSY+s0zpG8xXhaGKCw0=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.27.2/go.mod h1:PtQC3XjutCYFCn1+i8+wtpDaXvEK+vXF2gyLIKAmh4A=
+github.com/aws/aws-sdk-go-v2/service/sso v1.25.3/go.mod h1:qs4a9T5EMLl/Cajiw2TcbNt2UNo/Hqlyp+GiuG4CFDI=
+github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.1/go.mod h1:MlYRNmYu/fGPoxBQVvBYr9nyr948aY/WLUvwBMBJubs=
+github.com/aws/aws-sdk-go-v2/service/sts v1.33.19/go.mod h1:cQnB8CUnxbMU82JvlqjKR2HBOm3fe9pWorWBza6MBJ4=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
 github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
 github.com/beevik/etree v1.1.3/go.mod h1:MEjUJqV1InUci5lSfeIonCXMjsMW9yC3APDqKtnyNQg=
@@ -257,7 +263,6 @@ github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgr
 github.com/opencontainers/runtime-spec v1.2.1/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v1.13.0/go.mod h1:XxWTed+A/s5NNq4GmYScVy+9jzXhGBVEOAyucdRUY8s=
 github.com/openshift/build-machinery-go v0.0.0-20250530140348-dc5b2804eeee/go.mod h1:8jcm8UPtg2mCAsxfqKil1xrmRMI3a+XU2TZ9fF8A7TE=
-github.com/openshift/library-go v0.0.0-20260505113324-de46cb8e2ddc/go.mod h1:k1tefCr+PAZ7kY8TJjpE6rW6t6Yu4iOmBwO+1+3qD2s=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
@@ -488,6 +493,7 @@ k8s.io/cli-runtime v0.33.0/go.mod h1:QcA+r43HeUM9jXFJx7A+yiTPfCooau/iCcP1wQh4NFw
 k8s.io/cli-runtime v0.35.0/go.mod h1:VBRvHzosVAoVdP3XwUQn1Oqkvaa8facnokNkD7jOTMY=
 k8s.io/client-go v0.35.0/go.mod h1:q2E5AAyqcbeLGPdoRB+Nxe3KYTfPce1Dnu1myQdqz9o=
 k8s.io/client-go v0.35.1/go.mod h1:1p1KxDt3a0ruRfc/pG4qT/3oHmUj1AhSHEcxNSGg+OA=
+k8s.io/cloud-provider v0.35.0/go.mod h1:7grN+/Nt5Hf7tnSGPT3aErt4K7aQpygyCrGpbrQbzNc=
 k8s.io/cluster-bootstrap v0.35.0/go.mod h1:X6sjEjVUFSfFNIzJ6VAIuwwh2QiDtsVX1xZgcGX4gD8=
 k8s.io/code-generator v0.35.0/go.mod h1:iS1gvVf3c/T71N5DOGYO+Gt3PdJ6B9LYSvIyQ4FHzgc=
 k8s.io/component-base v0.35.0/go.mod h1:85SCX4UCa6SCFt6p3IKAPej7jSnF3L8EbfSyMZayJR0=

--- a/pkg/cloud/vsphere/vsphere_config_transformer.go
+++ b/pkg/cloud/vsphere/vsphere_config_transformer.go
@@ -77,6 +77,9 @@ func setNodes(cfg *ccmConfig.CPIConfig, nodeNetworking *configv1.VSpherePlatform
 
 // setVirtualCenters sets vcenter server sections according passed VSpherePlatformSpec
 func setVirtualCenters(cfg *ccmConfig.CPIConfig, vSphereSpec *configv1.VSpherePlatformSpec) {
+	// Clear existing vcenters to ensure removed vcenters are not carried over
+	cfg.Vcenter = make(map[string]*ccmConfig.VirtualCenterConfig)
+
 	for _, vcenter := range vSphereSpec.VCenters {
 		cfg.Vcenter[vcenter.Server] = &ccmConfig.VirtualCenterConfig{
 			VCenterIP:   vcenter.Server,

--- a/pkg/cloud/vsphere/vsphere_config_transformer_test.go
+++ b/pkg/cloud/vsphere/vsphere_config_transformer_test.go
@@ -31,6 +31,19 @@ func newVsphereInfraBuilder() infraBuilder {
 	}
 }
 
+func newVsphereInfraBuilderWithoutSpec() infraBuilder {
+	return infraBuilder{
+		platformSpec: configv1.PlatformSpec{
+			Type:    configv1.VSpherePlatformType,
+			VSphere: nil,
+		},
+		platformStatus: configv1.PlatformStatus{
+			Type:    configv1.VSpherePlatformType,
+			VSphere: &configv1.VSpherePlatformStatus{},
+		},
+	}
+}
+
 type infraBuilder struct {
 	platformSpec   configv1.PlatformSpec
 	platformStatus configv1.PlatformStatus
@@ -71,6 +84,16 @@ func (b infraBuilder) withVSphereDefaultNodeNetworking() infraBuilder {
 	vspereSpecRef.NodeNetworking.Internal.ExcludeNetworkSubnetCIDR = []string{"192.0.2.0/24", "fe80::1/128"}
 	vspereSpecRef.NodeNetworking.Internal.NetworkSubnetCIDR = []string{"192.0.3.0/24", "fe80::4/128"}
 
+	return b
+}
+
+func (b infraBuilder) withDefaultVCenter() infraBuilder {
+	vcenterSpec := configv1.VSpherePlatformVCenterSpec{
+		Server:      "test-server",
+		Datacenters: []string{"DC1"},
+	}
+	vspereSpecRef := b.platformSpec.VSphere
+	vspereSpecRef.VCenters = append(vspereSpecRef.VCenters, vcenterSpec)
 	return b
 }
 
@@ -387,6 +410,31 @@ labels:
   zone: openshift-zone
   region: openshift-region`
 
+const yamlConfigWithMultipleVCenters = `
+global:
+  insecureFlag: true
+  secretName: vsphere-creds
+  secretNamespace: kube-system
+vcenter:
+  test-server:
+    server: test-server
+    port: 443
+    datacenters:
+    - DC1
+    - DC2
+    - DC3
+  old-server-1:
+    server: old-server-1
+    datacenters:
+    - OLD-DC1
+  old-server-2:
+    server: old-server-2
+    datacenters:
+    - OLD-DC2
+labels:
+  zone: openshift-zone
+  region: openshift-region`
+
 func TestCloudConfigTransformer(t *testing.T) {
 	testcases := []struct {
 		name             string
@@ -399,7 +447,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 	}{
 		{
 			name:             "in-tree to external with empty infra",
-			infraBuilder:     newVsphereInfraBuilder(),
+			infraBuilder:     newVsphereInfraBuilderWithoutSpec(),
 			networkBuilder:   makeDummyNetworkConfig(),
 			inputConfig:      iniConfigWithWorkspace,
 			equivalentConfig: iniConfigWithoutWorkspace,
@@ -407,7 +455,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 		},
 		{
 			name:             "in-tree to external with node networking",
-			infraBuilder:     newVsphereInfraBuilder().withVSphereDefaultNodeNetworking(),
+			infraBuilder:     newVsphereInfraBuilder().withDefaultVCenter().withVSphereDefaultNodeNetworking(),
 			networkBuilder:   makeDummyNetworkConfig(),
 			inputConfig:      iniConfigWithWorkspace,
 			equivalentConfig: iniConfigNodeNetworking,
@@ -431,7 +479,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 		},
 		{
 			name:             "yaml and ini config parsing results should be the same",
-			infraBuilder:     newVsphereInfraBuilder(),
+			infraBuilder:     newVsphereInfraBuilderWithoutSpec(),
 			networkBuilder:   makeDummyNetworkConfig(),
 			inputConfig:      yamlConfig,
 			equivalentConfig: iniConfigWithoutWorkspace,
@@ -447,7 +495,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 		},
 		{
 			name:             "yaml and ini config parsing results should be the same, node networking",
-			infraBuilder:     newVsphereInfraBuilder().withVSphereDefaultNodeNetworking(),
+			infraBuilder:     newVsphereInfraBuilder().withDefaultVCenter().withVSphereDefaultNodeNetworking(),
 			networkBuilder:   makeDummyNetworkConfig(),
 			inputConfig:      yamlConfigNodeNetworking,
 			equivalentConfig: iniConfigNodeNetworking,
@@ -455,7 +503,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 		},
 		{
 			name:             "yaml config should contain node networking if it's specified in infra",
-			infraBuilder:     newVsphereInfraBuilder().withVSphereDefaultNodeNetworking(),
+			infraBuilder:     newVsphereInfraBuilder().withDefaultVCenter().withVSphereDefaultNodeNetworking(),
 			networkBuilder:   makeDummyNetworkConfig(),
 			inputConfig:      yamlConfig,
 			equivalentConfig: yamlConfigNodeNetworking,
@@ -471,7 +519,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 		},
 		{
 			name:             "yaml config should contain ipv4-primary dual-stack config and correct excluded subnets",
-			infraBuilder:     newVsphereInfraBuilder().withVSphereDefaultNodeNetworking().withPrimaryIPv4VIP(),
+			infraBuilder:     newVsphereInfraBuilder().withDefaultVCenter().withVSphereDefaultNodeNetworking().withPrimaryIPv4VIP(),
 			networkBuilder:   withDualStackPrimaryIPv4NetworkConfig(),
 			inputConfig:      yamlConfig,
 			equivalentConfig: yamlConfigNodeNetworkingDualStackPrimaryIPv4,
@@ -479,7 +527,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 		},
 		{
 			name:             "yaml config should contain ipv6-primary dual-stack config and correct excluded subnets",
-			infraBuilder:     newVsphereInfraBuilder().withVSphereDefaultNodeNetworking().withPrimaryIPv6VIP(),
+			infraBuilder:     newVsphereInfraBuilder().withDefaultVCenter().withVSphereDefaultNodeNetworking().withPrimaryIPv6VIP(),
 			networkBuilder:   withDualStackPrimaryIPv6NetworkConfig(),
 			inputConfig:      yamlConfig,
 			equivalentConfig: yamlConfigNodeNetworkingDualStackPrimaryIPv6,
@@ -487,7 +535,7 @@ func TestCloudConfigTransformer(t *testing.T) {
 		},
 		{
 			name:             "yaml config should contain ipv6-only config and correct excluded subnets",
-			infraBuilder:     newVsphereInfraBuilder().withVSphereIPv6onlyNodeNetworking().withIPv6onlyVIP(),
+			infraBuilder:     newVsphereInfraBuilder().withDefaultVCenter().withVSphereIPv6onlyNodeNetworking().withIPv6onlyVIP(),
 			networkBuilder:   withIPv6onlyNetworkConfig(),
 			inputConfig:      yamlConfig,
 			equivalentConfig: yamlConfigNodeNetworkingIPv6only,
@@ -514,6 +562,14 @@ func TestCloudConfigTransformer(t *testing.T) {
 			inputConfig:    ":",
 			errMsg:         "failed to read the cloud.conf",
 			features:       featuregates.NewFeatureGate(nil, nil),
+		},
+		{
+			name:             "removing vcenters should clean up old vcenters from config",
+			infraBuilder:     newVsphereInfraBuilder().withVSphereZones(),
+			networkBuilder:   makeDummyNetworkConfig(),
+			inputConfig:      yamlConfigWithMultipleVCenters,
+			equivalentConfig: yamlConfigZonal,
+			features:         featuregates.NewFeatureGate(nil, nil),
 		},
 	}
 


### PR DESCRIPTION
[SPLAT-2792](https://redhat.atlassian.net/browse/SPLAT-2792)

### Changes
- Fixed vSphere transformer to not copy over old vCenters from initial cloud config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where previously removed vCenters were persisting in the configuration after reconfiguration.

* **Tests**
  * Added test coverage to verify vCenter entries are properly cleaned up during configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->