### PR TITLE
TRT-2754: Revert "Updates clusteroperator_controller progressing"

### DIFF
--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -28,7 +28,6 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -129,7 +128,7 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 	}
 
 	if progressing {
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		return ctrl.Result{}, nil
 	}
 
 	if err := r.setStatusAvailable(ctx, conditionOverrides); err != nil {
@@ -165,17 +164,6 @@ func (r *CloudOperatorReconciler) sync(ctx context.Context, config config.Operat
 		return true, nil
 	}
 
-	converged, err := r.operandsConverged(ctx, resources)
-	if err != nil {
-		return false, err
-	}
-	if !converged {
-		if err := r.ensureStatusProgressing(ctx, conditionOverrides); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-
 	return false, nil
 }
 
@@ -202,76 +190,6 @@ func (r *CloudOperatorReconciler) applyResources(ctx context.Context, resources 
 	}
 
 	return anyUpdated, nil
-}
-
-func isDeploymentRolloutComplete(deploy *appsv1.Deployment) bool {
-	if deploy.Status.ObservedGeneration < deploy.Generation {
-		return false
-	}
-	for _, condition := range deploy.Status.Conditions {
-		if condition.Type == appsv1.DeploymentProgressing &&
-			condition.Status == corev1.ConditionTrue &&
-			condition.Reason == "NewReplicaSetAvailable" {
-			return true
-		}
-	}
-	return false
-}
-
-func isDeploymentRolloutStalled(deploy *appsv1.Deployment) bool {
-	if deploy.Status.ObservedGeneration < deploy.Generation {
-		return false
-	}
-	for _, condition := range deploy.Status.Conditions {
-		if condition.Type == appsv1.DeploymentProgressing &&
-			condition.Status == corev1.ConditionFalse &&
-			condition.Reason == "ProgressDeadlineExceeded" {
-			return true
-		}
-	}
-	return false
-}
-
-func isDaemonSetRolloutComplete(ds *appsv1.DaemonSet) bool {
-	return ds.Status.ObservedGeneration >= ds.Generation &&
-		ds.Status.UpdatedNumberScheduled >= ds.Status.DesiredNumberScheduled &&
-		ds.Status.NumberUnavailable == 0 &&
-		ds.Status.NumberMisscheduled == 0
-}
-
-func (r *CloudOperatorReconciler) operandsConverged(ctx context.Context, resources []client.Object) (bool, error) {
-	for _, resource := range resources {
-		switch resource.(type) {
-		case *appsv1.Deployment:
-			live := &appsv1.Deployment{}
-			if err := r.Get(ctx, client.ObjectKeyFromObject(resource), live); apierrors.IsNotFound(err) {
-				klog.V(2).Infof("Deployment %s not found, treating as not converged", resource.GetName())
-				return false, nil
-			} else if err != nil {
-				return false, fmt.Errorf("failed to get Deployment %s: %w", resource.GetName(), err)
-			}
-			if isDeploymentRolloutStalled(live) {
-				return false, fmt.Errorf("deployment %s rollout stalled: ProgressDeadlineExceeded", resource.GetName())
-			}
-			if !isDeploymentRolloutComplete(live) {
-				klog.V(2).Infof("Deployment %s rollout not complete", resource.GetName())
-				return false, nil
-			}
-		case *appsv1.DaemonSet:
-			live := &appsv1.DaemonSet{}
-			if err := r.Get(ctx, client.ObjectKeyFromObject(resource), live); apierrors.IsNotFound(err) {
-				klog.V(2).Infof("DaemonSet %s not found, treating as not converged", resource.GetName())
-				return false, nil
-			} else if err != nil {
-				return false, fmt.Errorf("failed to get DaemonSet %s: %w", resource.GetName(), err)
-			}
-			if !isDaemonSetRolloutComplete(live) {
-				klog.V(2).Infof("DaemonSet %s rollout not complete", resource.GetName())
-				return false, nil
-			}
-		}
-	}
-	return true, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -620,56 +620,17 @@ var _ = Describe("Apply resources should", func() {
 			}
 		}
 
-		updated, err = reconciler.applyResources(context.Background(), resources)
+		updated, err = reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated).To(BeTrue(), "should report updated even when only a non-final resource changed")
 	})
 
-	Context("operandsConverged", func() {
-		It("returns false when deployment rollout is not complete, true after patching status", func() {
-			operatorConfig := getConfigForPlatform(&configv1.PlatformStatus{Type: configv1.AWSPlatformType})
-			awsResources, err := cloud.GetResources(operatorConfig)
-			Expect(err).To(Succeed())
-			resources = append(resources, awsResources...)
-
-			updated, err := reconciler.applyResources(context.Background(), resources)
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(updated).To(BeTrue())
-
-			// envtest has no deployment controller, so no Progressing condition exists.
-			converged, err := reconciler.operandsConverged(context.Background(), resources)
-			Expect(err).To(Succeed())
-			Expect(converged).To(BeFalse(), "should not be converged when deployment has no Progressing condition")
-
-			// Patch the deployment status to mark rollout complete.
-			for _, res := range resources {
-				if dep, ok := res.(*appsv1.Deployment); ok {
-					live := &appsv1.Deployment{}
-					Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(dep), live)).To(Succeed())
-					live.Status.ObservedGeneration = live.Generation
-					live.Status.Conditions = []appsv1.DeploymentCondition{
-						{
-							Type:   appsv1.DeploymentProgressing,
-							Status: corev1.ConditionTrue,
-							Reason: "NewReplicaSetAvailable",
-						},
-					}
-					Expect(cl.Status().Update(context.Background(), live)).To(Succeed())
-				}
-			}
-
-			converged, err = reconciler.operandsConverged(context.Background(), resources)
-			Expect(err).To(Succeed())
-			Expect(converged).To(BeTrue(), "should be converged after deployment rollout completes")
-		})
-	})
-
-	It("should set Progressing=True on first sync, remain progressing until rollout completes, then stop", func() {
+	It("should set Progressing=True on first sync and not signal progressing when resources are stable", func() {
 		reconciler.ManagedNamespace = DefaultManagedNamespace
 
 		co := &configv1.ClusterOperator{}
 		co.SetName(clusterOperatorName)
-		Expect(cl.Create(context.Background(), co)).To(Succeed())
+		Expect(cl.Create(context.TODO(), co)).To(Succeed())
 
 		operatorConfig := getConfigForPlatform(&configv1.PlatformStatus{Type: configv1.AWSPlatformType})
 		awsResources, err := cloud.GetResources(operatorConfig)
@@ -677,45 +638,29 @@ var _ = Describe("Apply resources should", func() {
 		resources = append(resources, awsResources...)
 
 		// First sync: resources do not yet exist, so applyResources reports updated=true.
-		progressing, err := reconciler.sync(context.Background(), operatorConfig, nil)
+		progressing, err := reconciler.sync(context.TODO(), operatorConfig, nil)
 		Expect(err).To(Succeed())
 		Expect(progressing).To(BeTrue(), "sync should report progressing when resources are newly applied")
 
-		Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(cl.Get(context.TODO(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
 		progressingCond := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
 		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should exist after first sync")
 		Expect(progressingCond.Status).To(
 			Equal(configv1.ConditionTrue), "Progressing should be True after resources are first applied",
 		)
 
-		// Second sync: resources exist and are unchanged, but deployment rollout is
-		// not complete (envtest has no deployment controller). sync should still
-		// report progressing.
-		progressing, err = reconciler.sync(context.Background(), operatorConfig, nil)
+		// Second sync: resources exist and are unchanged, so applyResources reports updated=false.
+		progressing, err = reconciler.sync(context.TODO(), operatorConfig, nil)
 		Expect(err).To(Succeed())
-		Expect(progressing).To(BeTrue(), "sync should report progressing while deployment rollout is incomplete")
+		Expect(progressing).To(BeFalse(), "sync should not report progressing when resources are already up to date")
 
-		// Patch deployment status to mark rollout complete.
-		for _, res := range resources {
-			if dep, ok := res.(*appsv1.Deployment); ok {
-				live := &appsv1.Deployment{}
-				Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(dep), live)).To(Succeed())
-				live.Status.ObservedGeneration = live.Generation
-				live.Status.Conditions = []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-						Reason: "NewReplicaSetAvailable",
-					},
-				}
-				Expect(cl.Status().Update(context.Background(), live)).To(Succeed())
-			}
-		}
-
-		// Third sync: deployment rollout is complete, sync should report not progressing.
-		progressing, err = reconciler.sync(context.Background(), operatorConfig, nil)
-		Expect(err).To(Succeed())
-		Expect(progressing).To(BeFalse(), "sync should not report progressing once deployment rollout completes")
+		// Progressing remains True because sync() does not clear it; only setStatusAvailable() does.
+		Expect(cl.Get(context.TODO(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		progressingCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
+		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should still exist after second sync")
+		Expect(progressingCond.Status).To(
+			Equal(configv1.ConditionTrue), "Progressing should remain True until setStatusAvailable is called",
+		)
 	})
 
 	AfterEach(func() {
@@ -1067,7 +1012,7 @@ var _ = Describe("Reconcile progressing flow", func() {
 		}
 	})
 
-	It("sets Progressing=True on first reconcile, stays progressing until rollout completes, then Available", func() {
+	It("sets Progressing=True on first reconcile, then Available on second", func() {
 		// First Reconcile: resources are created, Progressing=True, Available not set.
 		_, err := reconciler.Reconcile(ctx, reconcile.Request{})
 		Expect(err).NotTo(HaveOccurred())
@@ -1097,8 +1042,7 @@ var _ = Describe("Reconcile progressing flow", func() {
 				"Available should not be True while progressing")
 		}
 
-		// Second Reconcile: nothing changed, but deployment rollout is not complete
-		// (envtest has no deployment controller). Progressing should remain True.
+		// Second Reconcile: nothing changed, Progressing=False, Available=True.
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1106,264 +1050,12 @@ var _ = Describe("Reconcile progressing flow", func() {
 		progressingCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
 		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should exist after second reconcile")
 		Expect(progressingCond.Status).To(
-			Equal(configv1.ConditionTrue), "Progressing should remain True while deployment rollout is incomplete",
-		)
-
-		// Patch deployment status to mark rollout complete.
-		for _, res := range operandResources {
-			if dep, ok := res.(*appsv1.Deployment); ok {
-				live := &appsv1.Deployment{}
-				Expect(cl.Get(ctx, client.ObjectKeyFromObject(dep), live)).To(Succeed())
-				live.Status.ObservedGeneration = live.Generation
-				live.Status.Conditions = []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-						Reason: "NewReplicaSetAvailable",
-					},
-				}
-				Expect(cl.Status().Update(ctx, live)).To(Succeed())
-			}
-		}
-
-		// Third Reconcile: deployment rollout is complete, Progressing=False, Available=True.
-		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
-		Expect(err).NotTo(HaveOccurred())
-
-		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
-		progressingCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
-		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should exist after third reconcile")
-		Expect(progressingCond.Status).To(
-			Equal(configv1.ConditionFalse), "Progressing should be False after deployment rollout completes",
+			Equal(configv1.ConditionFalse), "Progressing should be False after second reconcile with no changes",
 		)
 		availCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorAvailable)
-		Expect(availCond).NotTo(BeNil(), "Available condition should exist after third reconcile")
+		Expect(availCond).NotTo(BeNil(), "Available condition should exist after second reconcile")
 		Expect(availCond.Status).To(
-			Equal(configv1.ConditionTrue), "Available should be True after deployment rollout completes",
+			Equal(configv1.ConditionTrue), "Available should be True after second reconcile",
 		)
-	})
-})
-
-var _ = Describe("Rollout completion checks", func() {
-	Context("isDeploymentRolloutComplete", func() {
-		It("is not complete when no conditions exist", func() {
-			deploy := &appsv1.Deployment{}
-			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
-		})
-
-		It("is complete when ObservedGeneration matches and Reason=NewReplicaSetAvailable", func() {
-			deploy := &appsv1.Deployment{}
-			deploy.Generation = 2
-			deploy.Status = appsv1.DeploymentStatus{
-				ObservedGeneration: 2,
-				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-						Reason: "NewReplicaSetAvailable",
-					},
-				},
-			}
-			Expect(isDeploymentRolloutComplete(deploy)).To(BeTrue())
-		})
-
-		It("is not complete when ObservedGeneration lags behind Generation", func() {
-			deploy := &appsv1.Deployment{}
-			deploy.Generation = 3
-			deploy.Status = appsv1.DeploymentStatus{
-				ObservedGeneration: 2,
-				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-						Reason: "NewReplicaSetAvailable",
-					},
-				},
-			}
-			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
-		})
-
-		It("is not complete when Progressing=True with Reason=ReplicaSetUpdated", func() {
-			deploy := &appsv1.Deployment{}
-			deploy.Generation = 1
-			deploy.Status = appsv1.DeploymentStatus{
-				ObservedGeneration: 1,
-				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-						Reason: "ReplicaSetUpdated",
-					},
-				},
-			}
-			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
-		})
-
-		It("is not complete when Progressing=False due to deadline exceeded", func() {
-			deploy := &appsv1.Deployment{}
-			deploy.Generation = 1
-			deploy.Status = appsv1.DeploymentStatus{
-				ObservedGeneration: 1,
-				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionFalse,
-						Reason: "ProgressDeadlineExceeded",
-					},
-				},
-			}
-			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
-		})
-
-		It("is not complete when Progressing=True with Reason=FoundNewReplicaSet", func() {
-			deploy := &appsv1.Deployment{}
-			deploy.Generation = 1
-			deploy.Status = appsv1.DeploymentStatus{
-				ObservedGeneration: 1,
-				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-						Reason: "FoundNewReplicaSet",
-					},
-				},
-			}
-			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
-		})
-
-		It("keys off Progressing condition even when other conditions are present", func() {
-			deploy := &appsv1.Deployment{}
-			deploy.Generation = 1
-			deploy.Status = appsv1.DeploymentStatus{
-				ObservedGeneration: 1,
-				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentAvailable,
-						Status: corev1.ConditionTrue,
-						Reason: "MinimumReplicasAvailable",
-					},
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionTrue,
-						Reason: "NewReplicaSetAvailable",
-					},
-				},
-			}
-			Expect(isDeploymentRolloutComplete(deploy)).To(BeTrue())
-		})
-	})
-
-	Context("isDeploymentRolloutStalled", func() {
-		It("is stalled when ProgressDeadlineExceeded", func() {
-			deploy := &appsv1.Deployment{
-				Status: appsv1.DeploymentStatus{
-					Conditions: []appsv1.DeploymentCondition{
-						{
-							Type:   appsv1.DeploymentProgressing,
-							Status: corev1.ConditionFalse,
-							Reason: "ProgressDeadlineExceeded",
-						},
-					},
-				},
-			}
-			Expect(isDeploymentRolloutStalled(deploy)).To(BeTrue())
-		})
-
-		It("is not stalled during normal rollout", func() {
-			deploy := &appsv1.Deployment{
-				Status: appsv1.DeploymentStatus{
-					Conditions: []appsv1.DeploymentCondition{
-						{
-							Type:   appsv1.DeploymentProgressing,
-							Status: corev1.ConditionTrue,
-							Reason: "ReplicaSetUpdated",
-						},
-					},
-				},
-			}
-			Expect(isDeploymentRolloutStalled(deploy)).To(BeFalse())
-		})
-
-		It("is not stalled when no conditions exist", func() {
-			deploy := &appsv1.Deployment{}
-			Expect(isDeploymentRolloutStalled(deploy)).To(BeFalse())
-		})
-
-		It("ignores stale ProgressDeadlineExceeded from a previous generation", func() {
-			deploy := &appsv1.Deployment{}
-			deploy.Generation = 2
-			deploy.Status = appsv1.DeploymentStatus{
-				ObservedGeneration: 1,
-				Conditions: []appsv1.DeploymentCondition{
-					{
-						Type:   appsv1.DeploymentProgressing,
-						Status: corev1.ConditionFalse,
-						Reason: "ProgressDeadlineExceeded",
-					},
-				},
-			}
-			Expect(isDeploymentRolloutStalled(deploy)).To(BeFalse())
-		})
-	})
-
-	Context("isDaemonSetRolloutComplete", func() {
-		It("is not complete when UpdatedNumberScheduled < DesiredNumberScheduled", func() {
-			ds := &appsv1.DaemonSet{}
-			ds.Generation = 1
-			ds.Status = appsv1.DaemonSetStatus{
-				ObservedGeneration:     1,
-				DesiredNumberScheduled: 3,
-				UpdatedNumberScheduled: 1,
-			}
-			Expect(isDaemonSetRolloutComplete(ds)).To(BeFalse())
-		})
-
-		It("is not complete when NumberMisscheduled > 0 even if updated count matches", func() {
-			ds := &appsv1.DaemonSet{}
-			ds.Generation = 1
-			ds.Status = appsv1.DaemonSetStatus{
-				ObservedGeneration:     1,
-				DesiredNumberScheduled: 3,
-				UpdatedNumberScheduled: 3,
-				NumberMisscheduled:     1,
-			}
-			Expect(isDaemonSetRolloutComplete(ds)).To(BeFalse())
-		})
-
-		It("is not complete when NumberUnavailable > 0 even if scheduled counts match", func() {
-			ds := &appsv1.DaemonSet{}
-			ds.Generation = 1
-			ds.Status = appsv1.DaemonSetStatus{
-				ObservedGeneration:     1,
-				DesiredNumberScheduled: 3,
-				UpdatedNumberScheduled: 3,
-				NumberUnavailable:      1,
-			}
-			Expect(isDaemonSetRolloutComplete(ds)).To(BeFalse())
-		})
-
-		It("is not complete when ObservedGeneration lags behind Generation", func() {
-			ds := &appsv1.DaemonSet{}
-			ds.Generation = 2
-			ds.Status = appsv1.DaemonSetStatus{
-				ObservedGeneration:     1,
-				DesiredNumberScheduled: 3,
-				UpdatedNumberScheduled: 3,
-			}
-			Expect(isDaemonSetRolloutComplete(ds)).To(BeFalse())
-		})
-
-		It("is complete when all conditions are met", func() {
-			ds := &appsv1.DaemonSet{}
-			ds.Generation = 2
-			ds.Status = appsv1.DaemonSetStatus{
-				ObservedGeneration:     2,
-				DesiredNumberScheduled: 3,
-				UpdatedNumberScheduled: 3,
-				NumberMisscheduled:     0,
-				NumberUnavailable:      0,
-			}
-			Expect(isDaemonSetRolloutComplete(ds)).To(BeTrue())
-		})
 	})
 })

--- a/pkg/controllers/status.go
+++ b/pkg/controllers/status.go
@@ -110,20 +110,6 @@ func (r *ClusterOperatorStatusClient) setStatusProgressing(ctx context.Context, 
 	return r.syncStatus(ctx, co, conds, overrides)
 }
 
-func (r *ClusterOperatorStatusClient) ensureStatusProgressing(ctx context.Context, overrides []configv1.ClusterOperatorStatusCondition) error {
-	co, err := r.getOrCreateClusterOperator(ctx)
-	if err != nil {
-		return err
-	}
-	progressing := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
-	upgradeable := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorUpgradeable)
-	if progressing != nil && progressing.Status == configv1.ConditionTrue &&
-		upgradeable != nil && upgradeable.Status == configv1.ConditionTrue {
-		return nil
-	}
-	return r.setStatusProgressing(ctx, overrides)
-}
-
 // setStatusAvailable sets the Available condition to True, with the given reason
 // and message, and sets both the Progressing and Degraded conditions to False.
 func (r *ClusterOperatorStatusClient) setStatusAvailable(ctx context.Context, overrides []configv1.ClusterOperatorStatusCondition) error {


### PR DESCRIPTION
Reverts openshift/cluster-cloud-controller-manager-operator#473

This pull had changed the timing of ClusterOperator `status`, which blew out an existing race in the order of this operator's manifests:

```console
$ oc adm release extract --to manifests registry.ci.openshift.org/ocp/release-5:5.0.0-0.ci-2026-06-24-155404
Extracted release payload from digest sha256:bfd1f73616f3e78d0249bdd6c83fe93ab95fcdb508437c8d81dc8db1bd415d07 created at 2026-06-24T15:54:30Z
$ ls manifests/0000_26_cloud-controller-manager-operator_* | sort
manifests/0000_26_cloud-controller-manager-operator_00_namespace.yaml
manifests/0000_26_cloud-controller-manager-operator_01_images.configmap.yaml
manifests/0000_26_cloud-controller-manager-operator_02_rbac_operator.yaml
manifests/0000_26_cloud-controller-manager-operator_03_rbac_provider.yaml
manifests/0000_26_cloud-controller-manager-operator_04_rbac_provider_openstack.yaml
manifests/0000_26_cloud-controller-manager-operator_05_metrics-service.yaml
manifests/0000_26_cloud-controller-manager-operator_10_networkpolicy-default-deny.yaml
manifests/0000_26_cloud-controller-manager-operator_11_deployment.yaml
manifests/0000_26_cloud-controller-manager-operator_12_clusteroperator.yaml
manifests/0000_26_cloud-controller-manager-operator_13_credentialsrequest-openstack.yaml
manifests/0000_26_cloud-controller-manager-operator_14_credentialsrequest-azure.yaml
manifests/0000_26_cloud-controller-manager-operator_15_credentialsrequest-ibm.yaml
manifests/0000_26_cloud-controller-manager-operator_15_credentialsrequest-powervs.yaml
manifests/0000_26_cloud-controller-manager-operator_16_credentialsrequest-gcp.yaml
manifests/0000_26_cloud-controller-manager-operator_17_credentialsrequest-vsphere.yaml
manifests/0000_26_cloud-controller-manager-operator_18_credentialsrequest-nutanix.yaml
```

Runs like [this presubmit][1] from that pull are failing on:

```
level=error msg=Cluster operator cloud-controller-manager Degraded is True with SyncingFailed: Failed to resync for operator: 5.0.0-0.ci-2026-06-22-154600-test-ci-op-xd8g6x2b-latest because &{%!e(string=failed to sync operands: deployment azure-cloud-controller-manager rollout stalled: ProgressDeadlineExceeded) %!e(*errors.errorString=&{deployment azure-cloud-controller-manager rollout stalled: ProgressDeadlineExceeded})}
level=error msg=Bootstrap failed to complete: timed out waiting for the condition
```

with that Deployment starving on the lack of a cloud-cred secret, so the ClusterOperator doesn't go happy, so the CVO stops at the `12_clusteroperator.yaml` manifest without continuing on to the `14_credentialsrequest-azure.yaml` manifest that would unstick the Deployment.  We should instead push the CredentialsRequest manifests before the Deploynent manifest that depends on those Secrets.  But for now, revert, because we can merge-button a revert to unstick CI, and then we'll come in again with a rerevert and order-fix later.

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-cloud-controller-manager-operator/473/pull-ci-openshift-cluster-cloud-controller-manager-operator-main-level0-clusterinfra-azure-ipi-proxy-tests/2069082722420133888

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated operator status handling so progress is reported more directly during reconciliation.
  * The operator now stops requeueing as aggressively while work is in progress, reducing unnecessary follow-up cycles.
  * Once resources are stable, the operator transitions from **Progressing** to **Available** more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->