### PR TITLE
OCPBUGS-87334: update Dockerfile base image to ocp/5.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN make build &&\
     gzip /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/openshift-tests/bin/cloud-controller-manager-aws-tests-ext &&\
     gzip /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/openshift-tests/bin/cloud-controller-manager-operator-tests-ext
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/bin/cluster-controller-manager-operator .
 COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/bin/config-sync-controllers .
 COPY --from=builder /go/src/github.com/openshift/cluster-cloud-controller-manager-operator/bin/azure-config-credentials-injector .


### PR DESCRIPTION
Fixes the ART consistency issue for OCPBUGS-87334.

PR #470 (the ART bot's PR) changes both `.ci-operator.yaml` and the Dockerfile, but `.ci-operator.yaml` on `main` already correctly uses `rhel-9-release-golang-1.26-openshift-5.0`. The ART PR incorrectly downgrades it to `golang-1.25`, which conflicts with `go.work`'s `go 1.26.0` requirement, causing every CI job to fail with:

```
go: go.work requires go >= 1.26.0 (running go 1.25.8; GOTOOLCHAIN=local)
```

This PR makes only the correct change: updating the Dockerfile runtime base image from `ocp/4.22:base-rhel9` to `ocp/5.0:base-rhel9`, leaving `.ci-operator.yaml` untouched.

Supersedes #470.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s container base image to a newer supported release. This should help keep the build environment current and maintain compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->