### PR TITLE
OCPBUGS-94183, OCPBUGS-94184: [release-4.22] Add transient error handling across all three controllers, fix progressing=true

### DIFF
--- a/pkg/controllers/cloud_config_sync_controller.go
+++ b/pkg/controllers/cloud_config_sync_controller.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
@@ -35,34 +36,46 @@ type CloudConfigReconciler struct {
 	ClusterOperatorStatusClient
 	Scheme            *runtime.Scheme
 	FeatureGateAccess featuregates.FeatureGateAccess
+	failures          failureWindow
 }
 
-func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+// handleTerminal degrades immediately and returns nil so controller-runtime does not requeue.
+// An existing watch on the relevant resource will re-trigger reconciliation when fixed.
+// name labels log messages.
+func (fw *failureWindow) handleTerminal(name string, err error, setDegraded func() error) (ctrl.Result, error) {
+	klog.Errorf("%s: terminal error, setting degraded: %v", name, err)
+	if setErr := setDegraded(); setErr != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set degraded condition: %w", setErr)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	klog.V(1).Infof("Syncing cloud-conf ConfigMap")
 
+	defer finalizeReconcile(&r.failures, r.Clock, noStalenessWindow, transientDegradedThreshold, "CloudConfigReconciler", r.failures.clear, degradedSetter(ctx, r.setDegradedCondition), &result, &retErr)
+
 	infra := &configv1.Infrastructure{}
-	if err := r.Get(ctx, client.ObjectKey{Name: infrastructureResourceName}, infra); err != nil {
-		klog.Errorf("infrastructure resource not found")
-		if err := r.setDegradedCondition(ctx); err != nil {
+	if err := r.Get(ctx, client.ObjectKey{Name: infrastructureResourceName}, infra); apierrors.IsNotFound(err) {
+		// No cloud platform: mirror the main controller's behaviour of returning Available.
+		klog.Infof("Infrastructure cluster does not exist. Skipping...")
+		if err := r.setAvailableCondition(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
 		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to get Infrastructure: %w", err)
 	}
 
 	network := &configv1.Network{}
 	if err := r.Get(ctx, client.ObjectKey{Name: "cluster"}, network); err != nil {
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller when getting cluster Network object: %v", err)
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to get cluster Network: %w", err)
 	}
 
 	syncNeeded, err := r.isCloudConfigSyncNeeded(infra.Status.PlatformStatus, infra.Spec.CloudConfig)
 	if err != nil {
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
-		}
-		return ctrl.Result{}, err
+		// nil platformStatus is a terminal misconfiguration.
+		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("failed to check cloud config sync requirements: %w", err))
 	}
 	if !syncNeeded {
 		if err := r.setAvailableCondition(ctx); err != nil {
@@ -74,11 +87,9 @@ func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	cloudConfigTransformerFn, needsManagedConfigLookup, err := cloud.GetCloudConfigTransformer(infra.Status.PlatformStatus)
 	if err != nil {
+		// Unsupported platform won't change without a cluster reconfigure.
 		klog.Errorf("unable to get cloud config transformer function; unsupported platform")
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("failed to get cloud config transformer: %w", err))
 	}
 
 	sourceCM := &corev1.ConfigMap{}
@@ -99,14 +110,10 @@ func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 		if err := r.Get(ctx, defaultSourceCMObjectKey, sourceCM); err == nil {
 			managedConfigFound = true
-		} else if errors.IsNotFound(err) {
+		} else if apierrors.IsNotFound(err) {
 			klog.Warningf("managed cloud-config is not found, falling back to infrastructure config")
-		} else if err != nil {
-			klog.Errorf("unable to get managed cloud-config for sync")
-			if err := r.setDegradedCondition(ctx); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
-			}
-			return ctrl.Result{}, err
+		} else {
+			return ctrl.Result{}, fmt.Errorf("failed to get managed cloud config: %w", err)
 		}
 	}
 
@@ -116,53 +123,40 @@ func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			Name:      infra.Spec.CloudConfig.Name,
 			Namespace: OpenshiftConfigNamespace,
 		}
-		if err := r.Get(ctx, openshiftUnmanagedCMKey, sourceCM); errors.IsNotFound(err) {
+		if err := r.Get(ctx, openshiftUnmanagedCMKey, sourceCM); apierrors.IsNotFound(err) {
 			klog.Warningf("managed cloud-config is not found, falling back to default cloud config.")
 		} else if err != nil {
 			klog.Errorf("unable to get cloud-config for sync: %v", err)
-			if err := r.setDegradedCondition(ctx); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
-			}
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("failed to get cloud-config for sync: %w", err)
 		}
 	}
 
 	sourceCM, err = r.prepareSourceConfigMap(sourceCM, infra)
 	if err != nil {
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
-		}
-		return ctrl.Result{}, err
+		// User-supplied key mismatch: terminal until the ConfigMap or Infrastructure changes.
+		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("failed to prepare source cloud config: %w", err))
 	}
 
-	// Check if FeatureGateAccess is configured
+	// Apply transformer if needed
 	if r.FeatureGateAccess == nil {
-		klog.Errorf("FeatureGateAccess is not configured")
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
-		}
-		return ctrl.Result{}, fmt.Errorf("FeatureGateAccess is not configured")
+		// Operator misconfiguration at startup: Terminal.
+		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("FeatureGateAccess is not configured"))
 	}
 
 	features, err := r.FeatureGateAccess.CurrentFeatureGates()
 	if err != nil {
+		// The feature-gate informer may not have synced yet: transient.
 		klog.Errorf("unable to get feature gates: %v", err)
-		if errD := r.setDegradedCondition(ctx); errD != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", errD)
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to get feature gates: %w", err)
 	}
-
 	if cloudConfigTransformerFn != nil {
 		// We ignore stuff in sourceCM.BinaryData. This isn't allowed to
 		// contain any key that overlaps with those found in sourceCM.Data and
 		// we're not expecting users to put their data in the former.
 		output, err := cloudConfigTransformerFn(sourceCM.Data[defaultConfigKey], infra, network, features)
 		if err != nil {
-			if err := r.setDegradedCondition(ctx); err != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
-			}
-			return ctrl.Result{}, err
+			// Platform-specific transform failed on the current config data: terminal.
+			return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("failed to transform cloud config: %w", err))
 		}
 		sourceCM.Data[defaultConfigKey] = output
 	}
@@ -174,7 +168,7 @@ func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	}
 
 	// If the config does not exist, it will be created later, so we can ignore a Not Found error
-	if err := r.Get(ctx, targetConfigMapKey, targetCM); err != nil && !errors.IsNotFound(err) {
+	if err := r.Get(ctx, targetConfigMapKey, targetCM); err != nil && !apierrors.IsNotFound(err) {
 		klog.Errorf("unable to get target cloud-config for sync")
 		if err := r.setDegradedCondition(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
@@ -193,10 +187,7 @@ func (r *CloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if err := r.syncCloudConfigData(ctx, sourceCM, targetCM); err != nil {
 		klog.Errorf("unable to sync cloud config")
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for cloud config controller: %v", err)
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to sync cloud config: %w", err)
 	}
 
 	if err := r.setAvailableCondition(ctx); err != nil {
@@ -279,7 +270,7 @@ func (r *CloudConfigReconciler) syncCloudConfigData(ctx context.Context, source 
 	// check if target config exists, create if not
 	err := r.Get(ctx, client.ObjectKeyFromObject(target), &corev1.ConfigMap{})
 
-	if err != nil && errors.IsNotFound(err) {
+	if err != nil && apierrors.IsNotFound(err) {
 		return r.Create(ctx, target)
 	} else if err != nil {
 		return err

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -119,7 +119,7 @@ var _ = Describe("isCloudConfigEqual reconciler method", func() {
 	}
 
 	It("should return 'true' if ConfigMaps content are equal", func() {
-		Expect(reconciler.isCloudConfigEqual(makeManagedCloudConfig(configv1.AzurePlatformType), makeManagedCloudConfig(configv1.AzurePlatformType))).Should(BeTrue())
+		Expect(reconciler.isCloudConfigEqual(makeManagedCloudConfig(configv1.AzurePlatformType), makeManagedCloudConfig(configv1.AzurePlatformType))).Should(BeTrue(), "configmaps with identical content should be considered equal")
 	})
 
 	It("should return 'false' if ConfigMaps content are not equal", func() {
@@ -142,8 +142,7 @@ var _ = Describe("prepareSourceConfigMap reconciler method", func() {
 	managedCloudConfig := makeManagedCloudConfig(configv1.AzurePlatformType)
 
 	It("not prepared config should be different with managed one", func() {
-		_, ok := infraCloudConfig.Data[infraCloudConfKey]
-		Expect(ok).Should(BeTrue())
+		Expect(infraCloudConfig.Data).To(HaveKey(infraCloudConfKey))
 		Expect(reconciler.isCloudConfigEqual(infraCloudConfig, managedCloudConfig)).Should(BeFalse())
 	})
 
@@ -152,9 +151,8 @@ var _ = Describe("prepareSourceConfigMap reconciler method", func() {
 		Expect(err).Should(Succeed())
 		_, ok := preparedConfig.Data[infraCloudConfKey]
 		Expect(ok).Should(BeFalse())
-		_, ok = preparedConfig.Data[defaultConfigKey]
-		Expect(ok).Should(BeTrue())
-		Expect(reconciler.isCloudConfigEqual(preparedConfig, managedCloudConfig)).Should(BeTrue())
+		Expect(preparedConfig.Data).To(HaveKey(defaultConfigKey))
+		Expect(reconciler.isCloudConfigEqual(preparedConfig, managedCloudConfig)).Should(BeTrue(), "prepared config should have content equal to the managed cloud config")
 	})
 
 	It("config preparation should not touch extra fields in infra ConfigMap", func() {
@@ -162,8 +160,7 @@ var _ = Describe("prepareSourceConfigMap reconciler method", func() {
 		extendedInfraConfig.Data = map[string]string{infraCloudConfKey: "{}", "{}": "{}"}
 		preparedConfig, err := reconciler.prepareSourceConfigMap(extendedInfraConfig, infra)
 		Expect(err).Should(Succeed())
-		_, ok := preparedConfig.Data[defaultConfigKey]
-		Expect(ok).Should(BeTrue())
+		Expect(preparedConfig.Data).To(HaveKey(defaultConfigKey))
 		Expect(len(preparedConfig.Data)).Should(BeEquivalentTo(2))
 	})
 })
@@ -348,8 +345,26 @@ var _ = Describe("Cloud config sync controller", func() {
 			}, timeout).Should(Succeed())
 			initialCMresourceVersion := syncedCloudConfigMap.ResourceVersion
 
+			// Introducing the consecutiveFailureWindow means that there's a field that could be racy
+			// between the manager calling Reconcile and the test calling Reconcile.
+			// In production, we only have 1 instance of the reconciler running.
+			// Create a fresh reconciler that is NOT registered with the manager.
+			// It shares the same API client (thread-safe) but has its own
+			// consecutiveFailureSince field, so no data race with the manager's copy.
+			freshReconciler := &CloudConfigReconciler{
+				ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+					Client:           cl,
+					Clock:            clocktesting.NewFakePassiveClock(time.Now()),
+					ManagedNamespace: targetNamespaceName,
+				},
+				Scheme: scheme.Scheme,
+				FeatureGateAccess: featuregates.NewHardcodedFeatureGateAccessForTesting(
+					nil, []configv1.FeatureGateName{"AWSServiceLBNetworkSecurityGroup"}, nil, nil,
+				),
+			}
+
 			request := reconcile.Request{NamespacedName: client.ObjectKey{Name: "foo", Namespace: "bar"}}
-			_, err := reconciler.Reconcile(ctx, request)
+			_, err := freshReconciler.Reconcile(ctx, request)
 			Expect(err).Should(Succeed())
 
 			Expect(cl.Get(ctx, syncedConfigMapKey, syncedCloudConfigMap)).Should(Succeed())
@@ -509,7 +524,7 @@ var _ = Describe("Cloud config sync reconciler", func() {
 			Expect(len(allCMs.Items)).To(BeEquivalentTo(1))
 		})
 
-		It("should error if a user-specified configmap key isn't present", func() {
+		It("should degrade immediately if a user-specified configmap key isn't present", func() {
 			infraResource := makeInfrastructureResource(configv1.AWSPlatformType)
 			infraResource.Spec.CloudConfig.Key = "notfound"
 			Expect(cl.Create(ctx, infraResource)).To(Succeed())
@@ -518,8 +533,19 @@ var _ = Describe("Cloud config sync reconciler", func() {
 			Expect(cl.Status().Update(ctx, infraResource.DeepCopy())).To(Succeed())
 
 			_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{})
-			Expect(err.Error()).To(ContainSubstring("specified in infra resource does not exist in source configmap"))
+			Expect(err).To(Succeed())
 
+			co := &configv1.ClusterOperator{}
+			Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+			var degradedCond *configv1.ClusterOperatorStatusCondition
+			for i := range co.Status.Conditions {
+				if co.Status.Conditions[i].Type == cloudConfigControllerDegradedCondition {
+					degradedCond = &co.Status.Conditions[i]
+					break
+				}
+			}
+			Expect(degradedCond).NotTo(BeNil())
+			Expect(degradedCond.Status).To(Equal(configv1.ConditionTrue))
 		})
 
 		It("should continue with reconcile when feature gates are available", func() {
@@ -584,15 +610,39 @@ var _ = Describe("Cloud config sync reconciler", func() {
 		})
 	})
 
-	It("reconcile should fail if no infra resource found", func() {
+	It("reconcile should succeed and be available if no infra resource found", func() {
 		_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{})
-		Expect(err.Error()).Should(BeEquivalentTo("infrastructures.config.openshift.io \"cluster\" not found"))
+		Expect(err).To(Succeed())
+
+		co := &configv1.ClusterOperator{}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		var availCond *configv1.ClusterOperatorStatusCondition
+		for i := range co.Status.Conditions {
+			if co.Status.Conditions[i].Type == cloudConfigControllerAvailableCondition {
+				availCond = &co.Status.Conditions[i]
+				break
+			}
+		}
+		Expect(availCond).NotTo(BeNil())
+		Expect(availCond.Status).To(Equal(configv1.ConditionTrue))
 	})
 
-	It("should fail if no PlatformStatus in infra resource presented ", func() {
+	It("should degrade immediately if no PlatformStatus in infra resource", func() {
 		infraResource := makeInfrastructureResource(configv1.AWSPlatformType)
 		Expect(cl.Create(ctx, infraResource)).To(Succeed())
 		_, err := reconciler.Reconcile(context.TODO(), ctrl.Request{})
-		Expect(err.Error()).Should(BeEquivalentTo("platformStatus is required"))
+		Expect(err).To(Succeed())
+
+		co := &configv1.ClusterOperator{}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		var degradedCond *configv1.ClusterOperatorStatusCondition
+		for i := range co.Status.Conditions {
+			if co.Status.Conditions[i].Type == cloudConfigControllerDegradedCondition {
+				degradedCond = &co.Status.Conditions[i]
+				break
+			}
+		}
+		Expect(degradedCond).NotTo(BeNil())
+		Expect(degradedCond.Status).To(Equal(configv1.ConditionTrue))
 	})
 })

--- a/pkg/controllers/cloud_config_sync_controller_test.go
+++ b/pkg/controllers/cloud_config_sync_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -22,6 +23,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 )
 
@@ -237,19 +239,7 @@ var _ = Describe("Cloud config sync controller", func() {
 		mgrCtxCancel()
 		Eventually(mgrStopped, timeout).Should(BeClosed())
 
-		co := &configv1.ClusterOperator{}
-		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
-		if err == nil || !apierrors.IsNotFound(err) {
-			Eventually(func() error {
-				return cl.Delete(context.Background(), co)
-			}).Should(SatisfyAny(
-				Not(HaveOccurred()),
-				MatchError(apierrors.IsNotFound, "IsNotFound"),
-			))
-		}
-		Eventually(func() error {
-			return cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
-		}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+		deleteClusterOperator(context.Background(), cl)
 
 		By("Cleanup resources")
 		deleteOptions := &client.DeleteOptions{
@@ -435,19 +425,7 @@ var _ = Describe("Cloud config sync reconciler", func() {
 			GracePeriodSeconds: ptr.To[int64](0),
 		}
 
-		co := &configv1.ClusterOperator{}
-		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
-		if err == nil || !apierrors.IsNotFound(err) {
-			Eventually(func() error {
-				return cl.Delete(context.Background(), co)
-			}).Should(SatisfyAny(
-				Not(HaveOccurred()),
-				MatchError(apierrors.IsNotFound, "IsNotFound"),
-			))
-		}
-		Eventually(func() error {
-			return cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
-		}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+		deleteClusterOperator(context.Background(), cl)
 
 		infra := &configv1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{
@@ -644,5 +622,120 @@ var _ = Describe("Cloud config sync reconciler", func() {
 		}
 		Expect(degradedCond).NotTo(BeNil())
 		Expect(degradedCond.Status).To(Equal(configv1.ConditionTrue))
+	})
+})
+
+var _ = Describe("CloudConfigReconciler error handling", func() {
+	ctx := context.Background()
+
+	AfterEach(func() {
+		deleteClusterOperator(ctx, cl)
+	})
+
+	It("transient error should not set cloudConfigControllerDegraded before threshold", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		getErr := fmt.Errorf("connection refused")
+		faultyClient := errorInjectingClient{Client: cl, getErr: &getErr, failType: &configv1.Infrastructure{}}
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+
+		reconciler := &CloudConfigReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           &faultyClient,
+				Clock:            fakeClock,
+				ManagedNamespace: testManagedNamespace,
+			},
+			Scheme:            scheme.Scheme,
+			FeatureGateAccess: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, nil, nil),
+		}
+
+		stepSize := transientDegradedThreshold / 5
+		for range 4 {
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{})
+			Expect(err).To(HaveOccurred(), "transient error should be returned for controller-runtime to requeue")
+			fakeClock.Step(stepSize)
+		}
+
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.IsStatusConditionTrue(co.Status.Conditions, cloudConfigControllerDegradedCondition)).To(BeFalse(),
+			"cloudConfigControllerDegraded should not be True before the transient threshold elapses")
+	})
+
+	It("transient error should set cloudConfigControllerDegraded after threshold is crossed", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		getErr := fmt.Errorf("connection refused")
+		faultyClient := errorInjectingClient{Client: cl, getErr: &getErr, failType: &configv1.Infrastructure{}}
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+
+		reconciler := &CloudConfigReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           &faultyClient,
+				Clock:            fakeClock,
+				ManagedNamespace: testManagedNamespace,
+			},
+			Scheme:            scheme.Scheme,
+			FeatureGateAccess: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, nil, nil),
+		}
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
+
+		fakeClock.Step(transientDegradedThreshold + time.Second)
+
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
+
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		var degradedCond *configv1.ClusterOperatorStatusCondition
+		for i := range co.Status.Conditions {
+			if co.Status.Conditions[i].Type == cloudConfigControllerDegradedCondition {
+				degradedCond = &co.Status.Conditions[i]
+				break
+			}
+		}
+		Expect(degradedCond).NotTo(BeNil(), "cloudConfigControllerDegraded condition should exist after threshold is crossed")
+		Expect(degradedCond.Status).To(Equal(configv1.ConditionTrue),
+			"cloudConfigControllerDegraded should be True after threshold is crossed")
+	})
+
+	It("successful reconcile resets the failure window so transient errors must start fresh", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		getErr := fmt.Errorf("connection refused")
+		faultyClient := errorInjectingClient{Client: cl, getErr: &getErr, failType: &configv1.Infrastructure{}}
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+
+		reconciler := &CloudConfigReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           &faultyClient,
+				Clock:            fakeClock,
+				ManagedNamespace: testManagedNamespace,
+			},
+			Scheme:            scheme.Scheme,
+			FeatureGateAccess: featuregates.NewHardcodedFeatureGateAccessForTesting(nil, nil, nil, nil),
+		}
+
+		By("opening the failure window with a transient error")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
+
+		By("clearing the fault so Reconcile succeeds via the Infrastructure-not-found path")
+		getErr = nil
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("advancing past the original threshold and re-injecting the fault")
+		fakeClock.Step(transientDegradedThreshold + time.Second)
+		getErr = fmt.Errorf("connection refused")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
+
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.IsStatusConditionTrue(co.Status.Conditions, cloudConfigControllerDegradedCondition)).To(BeFalse(),
+			"cloudConfigControllerDegraded should not be True because the failure window was reset by the successful reconcile")
 	})
 })

--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -121,9 +121,14 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("failed to build operator config: %w", err))
 	}
 
-	if err := r.sync(ctx, operatorConfig, conditionOverrides); err != nil {
+	progressing, err := r.sync(ctx, operatorConfig, conditionOverrides)
+	if err != nil {
 		klog.Errorf("Unable to sync operands: %s", err)
 		return ctrl.Result{}, fmt.Errorf("failed to sync operands: %w", err)
+	}
+
+	if progressing {
+		return ctrl.Result{}, nil
 	}
 
 	if err := r.setStatusAvailable(ctx, conditionOverrides); err != nil {
@@ -143,33 +148,35 @@ func (r *CloudOperatorReconciler) clearFailureWindow() {
 	r.failures.clear()
 }
 
-func (r *CloudOperatorReconciler) sync(ctx context.Context, config config.OperatorConfig, conditionOverrides []configv1.ClusterOperatorStatusCondition) error {
-	// Deploy resources for platform
+func (r *CloudOperatorReconciler) sync(ctx context.Context, config config.OperatorConfig, conditionOverrides []configv1.ClusterOperatorStatusCondition) (bool, error) {
 	resources, err := cloud.GetResources(config)
 	if err != nil {
-		return err
+		return false, err
 	}
 	updated, err := r.applyResources(ctx, resources)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if updated {
-		return r.setStatusProgressing(ctx, conditionOverrides)
+		if err := r.setStatusProgressing(ctx, conditionOverrides); err != nil {
+			return false, err
+		}
+		return true, nil
 	}
 
-	return nil
+	return false, nil
 }
 
 // applyResources will apply all resources as-is to the cluster, allowing adding of custom annotations and lables
 func (r *CloudOperatorReconciler) applyResources(ctx context.Context, resources []client.Object) (bool, error) {
-	updated := false
-	var err error
+	anyUpdated := false
 
 	for _, resource := range resources {
-		updated, err = resourceapply.ApplyResource(ctx, r.Client, r.Recorder, resource)
+		updated, err := resourceapply.ApplyResource(ctx, r.Client, r.Recorder, resource)
 		if err != nil {
 			return false, err
 		}
+		anyUpdated = anyUpdated || updated
 
 		if err := r.watcher.Watch(ctx, resource); err != nil {
 			klog.Errorf("Unable to establish watch on object %s '%s': %+v", resource.GetObjectKind().GroupVersionKind(), resource.GetName(), err)
@@ -182,7 +189,7 @@ func (r *CloudOperatorReconciler) applyResources(ctx context.Context, resources 
 		klog.V(2).Info("Resources applied successfully.")
 	}
 
-	return updated, nil
+	return anyUpdated, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -28,6 +28,7 @@ import (
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -128,7 +129,7 @@ func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request)
 	}
 
 	if progressing {
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	if err := r.setStatusAvailable(ctx, conditionOverrides); err != nil {
@@ -164,6 +165,17 @@ func (r *CloudOperatorReconciler) sync(ctx context.Context, config config.Operat
 		return true, nil
 	}
 
+	converged, err := r.operandsConverged(ctx, resources)
+	if err != nil {
+		return false, err
+	}
+	if !converged {
+		if err := r.ensureStatusProgressing(ctx, conditionOverrides); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
 	return false, nil
 }
 
@@ -190,6 +202,76 @@ func (r *CloudOperatorReconciler) applyResources(ctx context.Context, resources 
 	}
 
 	return anyUpdated, nil
+}
+
+func isDeploymentRolloutComplete(deploy *appsv1.Deployment) bool {
+	if deploy.Status.ObservedGeneration < deploy.Generation {
+		return false
+	}
+	for _, condition := range deploy.Status.Conditions {
+		if condition.Type == appsv1.DeploymentProgressing &&
+			condition.Status == corev1.ConditionTrue &&
+			condition.Reason == "NewReplicaSetAvailable" {
+			return true
+		}
+	}
+	return false
+}
+
+func isDeploymentRolloutStalled(deploy *appsv1.Deployment) bool {
+	if deploy.Status.ObservedGeneration < deploy.Generation {
+		return false
+	}
+	for _, condition := range deploy.Status.Conditions {
+		if condition.Type == appsv1.DeploymentProgressing &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == "ProgressDeadlineExceeded" {
+			return true
+		}
+	}
+	return false
+}
+
+func isDaemonSetRolloutComplete(ds *appsv1.DaemonSet) bool {
+	return ds.Status.ObservedGeneration >= ds.Generation &&
+		ds.Status.UpdatedNumberScheduled >= ds.Status.DesiredNumberScheduled &&
+		ds.Status.NumberUnavailable == 0 &&
+		ds.Status.NumberMisscheduled == 0
+}
+
+func (r *CloudOperatorReconciler) operandsConverged(ctx context.Context, resources []client.Object) (bool, error) {
+	for _, resource := range resources {
+		switch resource.(type) {
+		case *appsv1.Deployment:
+			live := &appsv1.Deployment{}
+			if err := r.Get(ctx, client.ObjectKeyFromObject(resource), live); apierrors.IsNotFound(err) {
+				klog.V(2).Infof("Deployment %s not found, treating as not converged", resource.GetName())
+				return false, nil
+			} else if err != nil {
+				return false, fmt.Errorf("failed to get Deployment %s: %w", resource.GetName(), err)
+			}
+			if isDeploymentRolloutStalled(live) {
+				return false, fmt.Errorf("deployment %s rollout stalled: ProgressDeadlineExceeded", resource.GetName())
+			}
+			if !isDeploymentRolloutComplete(live) {
+				klog.V(2).Infof("Deployment %s rollout not complete", resource.GetName())
+				return false, nil
+			}
+		case *appsv1.DaemonSet:
+			live := &appsv1.DaemonSet{}
+			if err := r.Get(ctx, client.ObjectKeyFromObject(resource), live); apierrors.IsNotFound(err) {
+				klog.V(2).Infof("DaemonSet %s not found, treating as not converged", resource.GetName())
+				return false, nil
+			} else if err != nil {
+				return false, fmt.Errorf("failed to get DaemonSet %s: %w", resource.GetName(), err)
+			}
+			if !isDaemonSetRolloutComplete(live) {
+				klog.V(2).Infof("DaemonSet %s rollout not complete", resource.GetName())
+				return false, nil
+			}
+		}
+	}
+	return true, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/controllers/clusteroperator_controller.go
+++ b/pkg/controllers/clusteroperator_controller.go
@@ -22,19 +22,21 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	"github.com/openshift/library-go/pkg/cloudprovider"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	"github.com/openshift/cluster-cloud-controller-manager-operator/pkg/cloud"
@@ -48,6 +50,13 @@ const (
 
 	// Condition type for Cloud Controller ownership
 	cloudControllerOwnershipCondition = "CloudControllerOwner"
+
+	// aggregatedTransientDegradedThreshold is how long transient errors must persist before
+	// the controller sets Degraded=True.
+	// This prevents brief API server blips during upgrades from immediately degrading the operator.
+	// Applies to top-level operator, and is longer in order
+	// to accomodate changes in the lower-level operators.
+	aggregatedTransientDegradedThreshold = 2*time.Minute + (30 * time.Second)
 )
 
 // CloudOperatorReconciler reconciles a ClusterOperator object
@@ -58,6 +67,7 @@ type CloudOperatorReconciler struct {
 	ImagesFile        string
 	FeatureGateAccess featuregates.FeatureGateAccess
 	TLSConfig         func(*tls.Config)
+	failures          failureWindow
 }
 
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list;watch;create;update;patch;delete
@@ -66,78 +76,71 @@ type CloudOperatorReconciler struct {
 // +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures,verbs=get;list;watch
 
 // Reconcile will process the cloud-controller-manager clusterOperator
-func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+func (r *CloudOperatorReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (result ctrl.Result, retErr error) {
 	conditionOverrides := []configv1.ClusterOperatorStatusCondition{}
 
-	infra := &configv1.Infrastructure{}
-	if err := r.Get(ctx, client.ObjectKey{Name: infrastructureResourceName}, infra); errors.IsNotFound(err) {
-		klog.Infof("Infrastructure cluster does not exist. Skipping...")
+	defer finalizeReconcile(
+		&r.failures, r.Clock,
+		noStalenessWindow, aggregatedTransientDegradedThreshold,
+		"CloudOperatorReconciler",
+		r.clearFailureWindow,
+		func() error { return r.setStatusDegraded(ctx, retErr, conditionOverrides) },
+		&result, &retErr,
+	)
 
+	infra := &configv1.Infrastructure{}
+	if err := r.Get(ctx, client.ObjectKey{Name: infrastructureResourceName}, infra); apierrors.IsNotFound(err) {
+		klog.Infof("Infrastructure cluster does not exist. Skipping...")
 		if err := r.setStatusAvailable(ctx, conditionOverrides); err != nil {
 			klog.Errorf("Unable to sync cluster operator status: %s", err)
-			return ctrl.Result{}, err
+			return ctrl.Result{}, fmt.Errorf("error syncing ClusterOperatorStatus: %w", err)
 		}
-
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, nil // defer clears failure window
 	} else if err != nil {
 		klog.Errorf("Unable to retrive Infrastructure object: %v", err)
-
-		if err := r.setStatusDegraded(ctx, err, conditionOverrides); err != nil {
-			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
-			return ctrl.Result{}, fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to get Infrastructure: %w", err)
 	}
 
 	allowedToProvision, err := r.provisioningAllowed(ctx, infra, conditionOverrides)
 	if err != nil {
 		klog.Errorf("Unable to determine cluster state to check if provision is allowed: %v", err)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to check if provisioning is allowed: %w", err)
 	} else if !allowedToProvision {
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, nil // defer clears failure window
 	}
 
 	clusterProxy := &configv1.Proxy{}
-	if err := r.Get(ctx, client.ObjectKey{Name: proxyResourceName}, clusterProxy); err != nil && !errors.IsNotFound(err) {
+	if err := r.Get(ctx, client.ObjectKey{Name: proxyResourceName}, clusterProxy); err != nil && !apierrors.IsNotFound(err) {
 		klog.Errorf("Unable to retrive Proxy object: %v", err)
-
-		if err := r.setStatusDegraded(ctx, err, conditionOverrides); err != nil {
-			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
-			return ctrl.Result{}, fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to get Proxy: %w", err)
 	}
 
 	operatorConfig, err := config.ComposeConfig(infra, clusterProxy, r.ImagesFile, r.ManagedNamespace, r.FeatureGateAccess, r.TLSConfig)
 	if err != nil {
 		klog.Errorf("Unable to build operator config %s", err)
-		if err := r.setStatusDegraded(ctx, err, conditionOverrides); err != nil {
-			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
-			return ctrl.Result{}, fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("failed to build operator config: %w", err))
 	}
 
 	if err := r.sync(ctx, operatorConfig, conditionOverrides); err != nil {
 		klog.Errorf("Unable to sync operands: %s", err)
-		if err := r.setStatusDegraded(ctx, err, conditionOverrides); err != nil {
-			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
-			return ctrl.Result{}, fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
-		}
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to sync operands: %w", err)
 	}
 
 	if err := r.setStatusAvailable(ctx, conditionOverrides); err != nil {
 		klog.Errorf("Unable to sync cluster operator status: %s", err)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("error syncing ClusterOperatorStatus: %w", err)
 	}
 
 	if err := r.clearCloudControllerOwnerCondition(ctx); err != nil {
 		klog.Errorf("Unable to clear CloudControllerOwner condition: %s", err)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, fmt.Errorf("failed to clear CloudControllerOwner condition: %w", err)
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, nil // defer clears failure window
+}
+
+func (r *CloudOperatorReconciler) clearFailureWindow() {
+	r.failures.clear()
 }
 
 func (r *CloudOperatorReconciler) sync(ctx context.Context, config config.OperatorConfig, conditionOverrides []configv1.ClusterOperatorStatusCondition) error {
@@ -215,10 +218,6 @@ func (r *CloudOperatorReconciler) provisioningAllowed(ctx context.Context, infra
 	// Check if dependant controllers are available
 	available, err := r.checkControllerConditions(ctx)
 	if err != nil {
-		if err := r.setStatusDegraded(ctx, err, conditionOverrides); err != nil {
-			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
-			return false, fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
-		}
 		return false, err
 	}
 	if !available {
@@ -246,11 +245,6 @@ func (r *CloudOperatorReconciler) provisioningAllowed(ctx context.Context, infra
 	external, err := cloudprovider.IsCloudProviderExternal(infra.Status.PlatformStatus)
 	if err != nil {
 		klog.Errorf("Could not determine external cloud provider state: %v", err)
-
-		if err := r.setStatusDegraded(ctx, err, conditionOverrides); err != nil {
-			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
-			return false, fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
-		}
 		return false, err
 	} else if !external {
 		klog.Infof("Platform does not require an external cloud provider. Skipping...")
@@ -270,11 +264,6 @@ func (r *CloudOperatorReconciler) isCloudControllersOwnedByCCM(ctx context.Conte
 	co, err := r.getOrCreateClusterOperator(ctx)
 	if err != nil {
 		klog.Errorf("Unable to retrive ClusterOperator object: %v", err)
-
-		if err := r.setStatusDegraded(ctx, err, conditionOverrides); err != nil {
-			klog.Errorf("Error syncing ClusterOperatorStatus: %v", err)
-			return false, fmt.Errorf("error syncing ClusterOperatorStatus: %v", err)
-		}
 		return false, err
 	}
 

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -52,18 +52,7 @@ var _ = Describe("Cluster Operator status controller", func() {
 	})
 
 	AfterEach(func() {
-		co := &configv1.ClusterOperator{}
-		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
-		if err == nil || !apierrors.IsNotFound(err) {
-			Eventually(func() error {
-				err := cl.Delete(context.Background(), operator)
-				if err == nil || apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}).Should(Succeed())
-		}
-		Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)).To(MatchError(apierrors.IsNotFound, "ClusterOperator should have been deleted"))
+		deleteClusterOperator(context.Background(), cl)
 	})
 
 	type testCase struct {
@@ -654,7 +643,9 @@ var _ = Describe("Apply resources should", func() {
 		Expect(progressing).To(BeTrue(), "sync should report progressing when resources are newly applied")
 
 		Expect(cl.Get(context.TODO(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
-		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing).Status).To(
+		progressingCond := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
+		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should exist after first sync")
+		Expect(progressingCond.Status).To(
 			Equal(configv1.ConditionTrue), "Progressing should be True after resources are first applied",
 		)
 
@@ -665,24 +656,15 @@ var _ = Describe("Apply resources should", func() {
 
 		// Progressing remains True because sync() does not clear it; only setStatusAvailable() does.
 		Expect(cl.Get(context.TODO(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
-		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing).Status).To(
+		progressingCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
+		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should still exist after second sync")
+		Expect(progressingCond.Status).To(
 			Equal(configv1.ConditionTrue), "Progressing should remain True until setStatusAvailable is called",
 		)
 	})
 
 	AfterEach(func() {
-		co := &configv1.ClusterOperator{}
-		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
-		if err == nil || !apierrors.IsNotFound(err) {
-			Eventually(func() error {
-				err := cl.Delete(context.Background(), co)
-				if err == nil || apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}, timeout).Should(Succeed())
-		}
-		Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)).To(MatchError(apierrors.IsNotFound, "ClusterOperator should have been deleted"))
+		deleteClusterOperator(context.Background(), cl)
 
 		for _, operand := range resources {
 			Expect(cl.Delete(context.Background(), operand)).To(Succeed())
@@ -705,17 +687,7 @@ var _ = Describe("CloudOperatorReconciler error handling", func() {
 	ctx := context.Background()
 
 	AfterEach(func() {
-		co := &configv1.ClusterOperator{}
-		if err := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); err == nil {
-			Eventually(func() error {
-				err := cl.Delete(ctx, co)
-				if err == nil || apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}).Should(Succeed())
-		}
-		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(MatchError(apierrors.IsNotFound, "ClusterOperator should have been deleted"))
+		deleteClusterOperator(ctx, cl)
 
 		infra := &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: infrastructureResourceName}}
 		cl.Delete(ctx, infra) //nolint:errcheck
@@ -812,7 +784,113 @@ var _ = Describe("CloudOperatorReconciler error handling", func() {
 		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorDegraded).Status).To(Equal(configv1.ConditionTrue))
 	})
 
-	It("successful reconcile clears the failure window so subsequent transient errors start fresh", func() {
+	It("transient error should not set OperatorDegraded before threshold", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		getErr := fmt.Errorf("connection refused")
+		faultyClient := errorInjectingClient{Client: cl, getErr: &getErr, failType: &configv1.Infrastructure{}}
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+
+		reconciler := &CloudOperatorReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           &faultyClient,
+				Clock:            fakeClock,
+				ManagedNamespace: defaultManagementNamespace,
+				Recorder:         record.NewFakeRecorder(32),
+			},
+			Scheme: scheme.Scheme,
+		}
+
+		// Reconcile several times, advancing the clock each iteration but
+		// staying under the threshold. OperatorDegraded must never be set.
+		stepSize := aggregatedTransientDegradedThreshold / 5
+		for range 4 {
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{})
+			Expect(err).To(HaveOccurred(), "transient error should be returned for controller-runtime to requeue")
+			fakeClock.Step(stepSize)
+		}
+
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorDegraded)).To(BeFalse(),
+			"OperatorDegraded should not be True before the transient threshold elapses")
+	})
+
+	It("transient error should set OperatorDegraded after threshold is crossed", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		getErr := fmt.Errorf("connection refused")
+		faultyClient := errorInjectingClient{Client: cl, getErr: &getErr, failType: &configv1.Infrastructure{}}
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+
+		reconciler := &CloudOperatorReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           &faultyClient,
+				Clock:            fakeClock,
+				ManagedNamespace: defaultManagementNamespace,
+				Recorder:         record.NewFakeRecorder(32),
+			},
+			Scheme: scheme.Scheme,
+		}
+
+		// First Reconcile opens the failure window.
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
+
+		// Advance past the threshold.
+		fakeClock.Step(aggregatedTransientDegradedThreshold + time.Second)
+
+		// Next Reconcile crosses the threshold and sets OperatorDegraded.
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
+
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		degradedCond := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorDegraded)
+		Expect(degradedCond).NotTo(BeNil(), "OperatorDegraded condition should exist after threshold is crossed")
+		Expect(degradedCond.Status).To(Equal(configv1.ConditionTrue),
+			"OperatorDegraded should be True after threshold is crossed")
+	})
+
+	It("successful reconcile resets the failure window so transient errors must start fresh", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		getErr := fmt.Errorf("connection refused")
+		faultyClient := errorInjectingClient{Client: cl, getErr: &getErr, failType: &configv1.Infrastructure{}}
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+
+		reconciler := &CloudOperatorReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           &faultyClient,
+				Clock:            fakeClock,
+				ManagedNamespace: defaultManagementNamespace,
+				Recorder:         record.NewFakeRecorder(32),
+			},
+			Scheme: scheme.Scheme,
+		}
+
+		By("opening the failure window with a transient error")
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
+
+		By("clearing the fault so Reconcile succeeds via the Infrastructure-not-found path")
+		getErr = nil
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("advancing past the original threshold and re-injecting the fault")
+		fakeClock.Step(aggregatedTransientDegradedThreshold + time.Second)
+		getErr = fmt.Errorf("connection refused")
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
+
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorDegraded)).To(BeFalse(),
+			"OperatorDegraded should not be True because the failure window was reset by the successful reconcile")
+	})
+
+	It("successful finalizeReconcile clears the failure window so subsequent transient errors start fresh", func() {
 		fakeClock := clocktesting.NewFakeClock(time.Now())
 		reconciler := &CloudOperatorReconciler{
 			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
@@ -914,16 +992,7 @@ var _ = Describe("Reconcile progressing flow", func() {
 	})
 
 	AfterEach(func() {
-		co := &configv1.ClusterOperator{}
-		if err := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); err == nil {
-			Eventually(func() error {
-				err := cl.Delete(ctx, co)
-				if err == nil || apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}).Should(Succeed())
-		}
+		deleteClusterOperator(ctx, cl)
 
 		infra := &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: infrastructureResourceName}}
 		cl.Delete(ctx, infra) //nolint:errcheck
@@ -962,7 +1031,9 @@ var _ = Describe("Reconcile progressing flow", func() {
 
 		co := &configv1.ClusterOperator{}
 		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
-		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing).Status).To(
+		progressingCond := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
+		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should exist after first reconcile")
+		Expect(progressingCond.Status).To(
 			Equal(configv1.ConditionTrue), "Progressing should be True after first reconcile creates resources",
 		)
 		availCond := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorAvailable)
@@ -976,10 +1047,14 @@ var _ = Describe("Reconcile progressing flow", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
-		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing).Status).To(
+		progressingCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
+		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should exist after second reconcile")
+		Expect(progressingCond.Status).To(
 			Equal(configv1.ConditionFalse), "Progressing should be False after second reconcile with no changes",
 		)
-		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorAvailable).Status).To(
+		availCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorAvailable)
+		Expect(availCond).NotTo(BeNil(), "Available condition should exist after second reconcile")
+		Expect(availCond.Status).To(
 			Equal(configv1.ConditionTrue), "Available should be True after second reconcile",
 		)
 	})

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -16,6 +17,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -53,12 +55,15 @@ var _ = Describe("Cluster Operator status controller", func() {
 		co := &configv1.ClusterOperator{}
 		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
 		if err == nil || !apierrors.IsNotFound(err) {
-			Eventually(func() bool {
+			Eventually(func() error {
 				err := cl.Delete(context.Background(), operator)
-				return err == nil || apierrors.IsNotFound(err)
-			}).Should(BeTrue())
+				if err == nil || apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}).Should(Succeed())
 		}
-		Eventually(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co))).Should(BeTrue())
+		Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)).To(MatchError(apierrors.IsNotFound, "ClusterOperator should have been deleted"))
 	})
 
 	type testCase struct {
@@ -89,14 +94,17 @@ var _ = Describe("Cluster Operator status controller", func() {
 			Expect(err).To(Succeed())
 
 			getOp := &configv1.ClusterOperator{}
-			Eventually(func() (bool, error) {
+			Eventually(func() error {
 				err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, getOp)
 				if err != nil {
-					return false, err
+					return err
 				}
 				// Successful sync means CO exists and the status is not empty
-				return getOp != nil && len(getOp.Status.Versions) > 0, nil
-			}, timeout).Should(BeTrue())
+				if getOp == nil || len(getOp.Status.Versions) == 0 {
+					return fmt.Errorf("ClusterOperator status versions not yet populated")
+				}
+				return nil
+			}, timeout).Should(Succeed())
 
 			// check version.
 			Expect(getOp.Status.Versions).To(HaveLen(1))
@@ -104,13 +112,13 @@ var _ = Describe("Cluster Operator status controller", func() {
 			Expect(getOp.Status.Versions[0].Version).To(Equal(expectedVersion))
 
 			// check conditions.
-			Expect(v1helpers.IsStatusConditionTrue(getOp.Status.Conditions, configv1.OperatorAvailable)).To(BeTrue())
+			Expect(v1helpers.FindStatusCondition(getOp.Status.Conditions, configv1.OperatorAvailable).Status).To(Equal(configv1.ConditionTrue))
 			Expect(v1helpers.FindStatusCondition(getOp.Status.Conditions, configv1.OperatorAvailable).Reason).To(Equal(ReasonAsExpected))
-			Expect(v1helpers.IsStatusConditionTrue(getOp.Status.Conditions, configv1.OperatorUpgradeable)).To(BeTrue())
+			Expect(v1helpers.FindStatusCondition(getOp.Status.Conditions, configv1.OperatorUpgradeable).Status).To(Equal(configv1.ConditionTrue))
 			Expect(v1helpers.FindStatusCondition(getOp.Status.Conditions, configv1.OperatorUpgradeable).Reason).To(Equal(ReasonAsExpected))
-			Expect(v1helpers.IsStatusConditionFalse(getOp.Status.Conditions, configv1.OperatorDegraded)).To(BeTrue())
+			Expect(v1helpers.FindStatusCondition(getOp.Status.Conditions, configv1.OperatorDegraded).Status).To(Equal(configv1.ConditionFalse))
 			Expect(v1helpers.FindStatusCondition(getOp.Status.Conditions, configv1.OperatorDegraded).Reason).To(Equal(ReasonAsExpected))
-			Expect(v1helpers.IsStatusConditionFalse(getOp.Status.Conditions, configv1.OperatorProgressing)).To(BeTrue())
+			Expect(v1helpers.FindStatusCondition(getOp.Status.Conditions, configv1.OperatorProgressing).Status).To(Equal(configv1.ConditionFalse))
 			Expect(v1helpers.FindStatusCondition(getOp.Status.Conditions, configv1.OperatorProgressing).Reason).To(Equal(ReasonAsExpected))
 			Expect(v1helpers.FindStatusCondition(getOp.Status.Conditions, cloudControllerOwnershipCondition)).To(BeNil())
 
@@ -292,7 +300,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		// two resources should report successful update, deployment and pdb
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
@@ -315,14 +323,14 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		dep.Spec.Replicas = ptr.To[int32](20)
 
 		updated, err = reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
 
 		// No update as resource didn't change
@@ -353,7 +361,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		// three resources should report successful update, deployment, pdb and service
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
@@ -382,7 +390,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		// Manually changing the port number
@@ -415,7 +423,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err = reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
 
 		// Checking that the port has been reverted back and there is only one item in the list
@@ -442,7 +450,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		// Manually adding another port
@@ -474,7 +482,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err = reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
 
 		// Checking that the port list has been reverted back and there is only one item in the list
@@ -505,7 +513,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		// Manually inserting a new label
@@ -531,7 +539,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err = reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
 
 		// Checking that the new label is still there
@@ -558,7 +566,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err := reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully created")))
 
 		// Now the deployment has just one label "k8s-app: aws-cloud-controller-manager"
@@ -587,7 +595,7 @@ var _ = Describe("Apply resources should", func() {
 
 		updated, err = reconciler.applyResources(context.TODO(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
-		Expect(updated).To(BeTrue())
+		Expect(updated).To(BeTrue(), "expected applyResources to report that at least one resource was created or updated")
 		Eventually(recorder.Events).Should(Receive(ContainSubstring("Resource was successfully updated")))
 
 		// Checking that the label value has been reverted and there is only one item in the map
@@ -601,20 +609,193 @@ var _ = Describe("Apply resources should", func() {
 		co := &configv1.ClusterOperator{}
 		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
 		if err == nil || !apierrors.IsNotFound(err) {
-			Eventually(func() bool {
+			Eventually(func() error {
 				err := cl.Delete(context.Background(), co)
-				return err == nil || apierrors.IsNotFound(err)
-			}, timeout).Should(BeTrue())
+				if err == nil || apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}, timeout).Should(Succeed())
 		}
-		Eventually(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co))).Should(BeTrue())
+		Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)).To(MatchError(apierrors.IsNotFound, "ClusterOperator should have been deleted"))
 
 		for _, operand := range resources {
 			Expect(cl.Delete(context.Background(), operand)).To(Succeed())
 
-			Eventually(func() bool {
-				return apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKeyFromObject(operand), operand))
-			}, timeout).Should(BeTrue())
+			Eventually(func() error {
+				err := cl.Get(context.Background(), client.ObjectKeyFromObject(operand), operand)
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("expected operand %s to be deleted", operand.GetName())
+			}, timeout).Should(Succeed())
 		}
 	})
 
+})
+
+var _ = Describe("CloudOperatorReconciler error handling", func() {
+	ctx := context.Background()
+
+	AfterEach(func() {
+		co := &configv1.ClusterOperator{}
+		if err := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); err == nil {
+			Eventually(func() error {
+				err := cl.Delete(ctx, co)
+				if err == nil || apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}).Should(Succeed())
+		}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(MatchError(apierrors.IsNotFound, "ClusterOperator should have been deleted"))
+
+		infra := &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: infrastructureResourceName}}
+		cl.Delete(ctx, infra) //nolint:errcheck
+	})
+
+	It("terminal error via finalizeReconcile should set OperatorDegraded=True immediately and return nil error", func() {
+		reconciler := &CloudOperatorReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            clocktesting.NewFakePassiveClock(time.Now()),
+				ManagedNamespace: defaultManagementNamespace,
+				Recorder:         record.NewFakeRecorder(32),
+			},
+			Scheme:     scheme.Scheme,
+			ImagesFile: "/nonexistent/images.json",
+		}
+
+		infra := &configv1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{Name: infrastructureResourceName},
+		}
+		Expect(cl.Create(ctx, infra)).To(Succeed())
+		infra.Status = configv1.InfrastructureStatus{
+			PlatformStatus:         &configv1.PlatformStatus{Type: configv1.AWSPlatformType},
+			Platform:               configv1.AWSPlatformType,
+			InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+			ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		}
+		Expect(cl.Status().Update(ctx, infra)).To(Succeed())
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+		co.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
+			{Type: cloudConfigControllerAvailableCondition, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Now()},
+			{Type: cloudConfigControllerDegradedCondition, Status: configv1.ConditionFalse, LastTransitionTime: metav1.Now()},
+			{Type: trustedCABundleControllerAvailableCondition, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Now()},
+			{Type: trustedCABundleControllerDegradedCondition, Status: configv1.ConditionFalse, LastTransitionTime: metav1.Now()},
+		}
+		Expect(cl.Status().Update(ctx, co)).To(Succeed())
+
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred(), "terminal errors should return nil so controller-runtime does not requeue")
+
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorDegraded).Status).To(Equal(configv1.ConditionTrue))
+	})
+
+	It("transient error via finalizeReconcile should not degrade before threshold, but degrade after threshold", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		reconciler := &CloudOperatorReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            fakeClock,
+				ManagedNamespace: defaultManagementNamespace,
+				Recorder:         record.NewFakeRecorder(32),
+			},
+			Scheme: scheme.Scheme,
+		}
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+
+		transientErr := fmt.Errorf("test transient error")
+		conditionOverrides := []configv1.ClusterOperatorStatusCondition{}
+
+		// Simulate what Reconcile's defer does: call finalizeReconcile with
+		// the same closure that Reconcile constructs.
+		callFinalizeReconcile := func(retErr error) (ctrl.Result, error) {
+			result := ctrl.Result{}
+			finalizeReconcile(
+				&reconciler.failures, reconciler.Clock,
+				noStalenessWindow, aggregatedTransientDegradedThreshold,
+				"CloudOperatorReconciler",
+				reconciler.clearFailureWindow,
+				func() error { return reconciler.setStatusDegraded(ctx, retErr, conditionOverrides) },
+				&result, &retErr,
+			)
+			return result, retErr
+		}
+
+		// First call: transient failure starts; error returned but no OperatorDegraded set.
+		_, err := callFinalizeReconcile(transientErr)
+		Expect(err).To(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorDegraded)).To(BeFalse(),
+			"should not be degraded before threshold")
+
+		// Advance clock past the degraded threshold.
+		fakeClock.Step(aggregatedTransientDegradedThreshold + time.Second)
+
+		// Second call: threshold exceeded, controller sets OperatorDegraded.
+		_, err = callFinalizeReconcile(transientErr)
+		Expect(err).To(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorDegraded).Status).To(Equal(configv1.ConditionTrue))
+	})
+
+	It("successful reconcile clears the failure window so subsequent transient errors start fresh", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		reconciler := &CloudOperatorReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            fakeClock,
+				ManagedNamespace: defaultManagementNamespace,
+				Recorder:         record.NewFakeRecorder(32),
+			},
+			Scheme: scheme.Scheme,
+		}
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+
+		transientErr := fmt.Errorf("test transient error")
+		conditionOverrides := []configv1.ClusterOperatorStatusCondition{}
+
+		callFinalizeReconcile := func(retErr error) (ctrl.Result, error) {
+			result := ctrl.Result{}
+			finalizeReconcile(
+				&reconciler.failures, reconciler.Clock,
+				noStalenessWindow, aggregatedTransientDegradedThreshold,
+				"CloudOperatorReconciler",
+				reconciler.clearFailureWindow,
+				func() error { return reconciler.setStatusDegraded(ctx, retErr, conditionOverrides) },
+				&result, &retErr,
+			)
+			return result, retErr
+		}
+
+		// Open the failure window with a transient error.
+		_, err := callFinalizeReconcile(transientErr)
+		Expect(err).To(HaveOccurred())
+
+		// Simulate a successful reconcile: nil error clears the window.
+		_, err = callFinalizeReconcile(nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Advance clock past the original threshold.
+		fakeClock.Step(aggregatedTransientDegradedThreshold + time.Second)
+
+		// Despite the clock being past threshold, the window was cleared
+		// by the successful reconcile — this starts a fresh window.
+		_, err = callFinalizeReconcile(transientErr)
+		Expect(err).To(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorDegraded)).To(BeFalse(),
+			"should not be degraded because the failure window was reset by the successful reconcile")
+	})
 })

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -605,6 +605,71 @@ var _ = Describe("Apply resources should", func() {
 		Expect(dep.Labels[common.CloudControllerManagerProviderLabel]).To(Equal("AWS"))
 	})
 
+	It("reports updated=true when only a non-final resource changed", func() {
+		operatorConfig := getConfigForPlatform(&configv1.PlatformStatus{Type: configv1.AWSPlatformType})
+		awsResources, err := cloud.GetResources(operatorConfig)
+		Expect(err).To(Succeed())
+		Expect(len(awsResources)).To(BeNumerically(">=", 2))
+
+		resources = append(resources, awsResources...)
+
+		updated, err := reconciler.applyResources(context.TODO(), resources)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(updated).To(BeTrue())
+
+		// Drain recorder events from initial creation
+		for len(recorder.Events) > 0 {
+			<-recorder.Events
+		}
+
+		// Modify only the deployment so it gets updated, while later resources remain unchanged
+		for i, res := range resources {
+			if dep, ok := res.(*appsv1.Deployment); ok {
+				dep.Spec.Replicas = ptr.To[int32](99)
+				resources[i] = dep
+				break
+			}
+		}
+
+		updated, err = reconciler.applyResources(context.TODO(), resources)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(updated).To(BeTrue(), "should report updated even when only a non-final resource changed")
+	})
+
+	It("should set Progressing=True on first sync and not signal progressing when resources are stable", func() {
+		reconciler.ManagedNamespace = DefaultManagedNamespace
+
+		co := &configv1.ClusterOperator{}
+		co.SetName(clusterOperatorName)
+		Expect(cl.Create(context.TODO(), co)).To(Succeed())
+
+		operatorConfig := getConfigForPlatform(&configv1.PlatformStatus{Type: configv1.AWSPlatformType})
+		awsResources, err := cloud.GetResources(operatorConfig)
+		Expect(err).To(Succeed())
+		resources = append(resources, awsResources...)
+
+		// First sync: resources do not yet exist, so applyResources reports updated=true.
+		progressing, err := reconciler.sync(context.TODO(), operatorConfig, nil)
+		Expect(err).To(Succeed())
+		Expect(progressing).To(BeTrue(), "sync should report progressing when resources are newly applied")
+
+		Expect(cl.Get(context.TODO(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing).Status).To(
+			Equal(configv1.ConditionTrue), "Progressing should be True after resources are first applied",
+		)
+
+		// Second sync: resources exist and are unchanged, so applyResources reports updated=false.
+		progressing, err = reconciler.sync(context.TODO(), operatorConfig, nil)
+		Expect(err).To(Succeed())
+		Expect(progressing).To(BeFalse(), "sync should not report progressing when resources are already up to date")
+
+		// Progressing remains True because sync() does not clear it; only setStatusAvailable() does.
+		Expect(cl.Get(context.TODO(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing).Status).To(
+			Equal(configv1.ConditionTrue), "Progressing should remain True until setStatusAvailable is called",
+		)
+	})
+
 	AfterEach(func() {
 		co := &configv1.ClusterOperator{}
 		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
@@ -634,7 +699,6 @@ var _ = Describe("Apply resources should", func() {
 			}, timeout).Should(Succeed())
 		}
 	})
-
 })
 
 var _ = Describe("CloudOperatorReconciler error handling", func() {
@@ -797,5 +861,126 @@ var _ = Describe("CloudOperatorReconciler error handling", func() {
 		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
 		Expect(v1helpers.IsStatusConditionTrue(co.Status.Conditions, configv1.OperatorDegraded)).To(BeFalse(),
 			"should not be degraded because the failure window was reset by the successful reconcile")
+	})
+})
+
+var _ = Describe("Reconcile progressing flow", func() {
+	ctx := context.Background()
+	var reconciler *CloudOperatorReconciler
+	var operandResources []client.Object
+
+	BeforeEach(func() {
+		c, err := cache.New(cfg, cache.Options{})
+		Expect(err).To(Succeed())
+
+		w, err := NewObjectWatcher(WatcherOptions{Cache: c})
+		Expect(err).To(Succeed())
+
+		reconciler = &CloudOperatorReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            clocktesting.NewFakePassiveClock(time.Now()),
+				ManagedNamespace: DefaultManagedNamespace,
+				Recorder:         record.NewFakeRecorder(32),
+			},
+			Scheme:     scheme.Scheme,
+			watcher:    w,
+			ImagesFile: testImagesFilePath,
+		}
+
+		infra := &configv1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{Name: infrastructureResourceName},
+		}
+		Expect(cl.Create(ctx, infra)).To(Succeed())
+
+		infra.Status = configv1.InfrastructureStatus{
+			PlatformStatus:         &configv1.PlatformStatus{Type: configv1.AWSPlatformType},
+			Platform:               configv1.AWSPlatformType,
+			InfrastructureTopology: configv1.HighlyAvailableTopologyMode,
+			ControlPlaneTopology:   configv1.HighlyAvailableTopologyMode,
+		}
+		Expect(cl.Status().Update(ctx, infra)).To(Succeed())
+
+		co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: clusterOperatorName}}
+		Expect(cl.Create(ctx, co)).To(Succeed())
+
+		co.Status.Conditions = []configv1.ClusterOperatorStatusCondition{
+			{Type: cloudConfigControllerAvailableCondition, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Now()},
+			{Type: cloudConfigControllerDegradedCondition, Status: configv1.ConditionFalse, LastTransitionTime: metav1.Now()},
+			{Type: trustedCABundleControllerAvailableCondition, Status: configv1.ConditionTrue, LastTransitionTime: metav1.Now()},
+			{Type: trustedCABundleControllerDegradedCondition, Status: configv1.ConditionFalse, LastTransitionTime: metav1.Now()},
+		}
+		Expect(cl.Status().Update(ctx, co)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		co := &configv1.ClusterOperator{}
+		if err := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); err == nil {
+			Eventually(func() error {
+				err := cl.Delete(ctx, co)
+				if err == nil || apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}).Should(Succeed())
+		}
+
+		infra := &configv1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Name: infrastructureResourceName}}
+		cl.Delete(ctx, infra) //nolint:errcheck
+
+		for _, res := range operandResources {
+			cl.Delete(ctx, res) //nolint:errcheck
+			Eventually(func() error {
+				err := cl.Get(ctx, client.ObjectKeyFromObject(res), res)
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("expected operand %s to be deleted", res.GetName())
+			}, timeout).Should(Succeed())
+		}
+	})
+
+	It("sets Progressing=True on first reconcile, then Available on second", func() {
+		// First Reconcile: resources are created, Progressing=True, Available not set.
+		_, err := reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Track created resources for cleanup
+		operatorConfig := config.OperatorConfig{
+			ManagedNamespace: DefaultManagedNamespace,
+			ImagesReference: config.ImagesReference{
+				CloudControllerManagerOperator: "registry.ci.openshift.org/openshift:cluster-cloud-controller-manager-operator",
+				CloudControllerManagerAWS:      "registry.ci.openshift.org/openshift:aws-cloud-controller-manager",
+			},
+			PlatformStatus: &configv1.PlatformStatus{Type: configv1.AWSPlatformType},
+		}
+		operandResources, err = cloud.GetResources(operatorConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		co := &configv1.ClusterOperator{}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing).Status).To(
+			Equal(configv1.ConditionTrue), "Progressing should be True after first reconcile creates resources",
+		)
+		availCond := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorAvailable)
+		if availCond != nil {
+			Expect(availCond.Status).NotTo(Equal(configv1.ConditionTrue),
+				"Available should not be True while progressing")
+		}
+
+		// Second Reconcile: nothing changed, Progressing=False, Available=True.
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing).Status).To(
+			Equal(configv1.ConditionFalse), "Progressing should be False after second reconcile with no changes",
+		)
+		Expect(v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorAvailable).Status).To(
+			Equal(configv1.ConditionTrue), "Available should be True after second reconcile",
+		)
 	})
 })

--- a/pkg/controllers/clusteroperator_controller_test.go
+++ b/pkg/controllers/clusteroperator_controller_test.go
@@ -620,17 +620,56 @@ var _ = Describe("Apply resources should", func() {
 			}
 		}
 
-		updated, err = reconciler.applyResources(context.TODO(), resources)
+		updated, err = reconciler.applyResources(context.Background(), resources)
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(updated).To(BeTrue(), "should report updated even when only a non-final resource changed")
 	})
 
-	It("should set Progressing=True on first sync and not signal progressing when resources are stable", func() {
+	Context("operandsConverged", func() {
+		It("returns false when deployment rollout is not complete, true after patching status", func() {
+			operatorConfig := getConfigForPlatform(&configv1.PlatformStatus{Type: configv1.AWSPlatformType})
+			awsResources, err := cloud.GetResources(operatorConfig)
+			Expect(err).To(Succeed())
+			resources = append(resources, awsResources...)
+
+			updated, err := reconciler.applyResources(context.Background(), resources)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(updated).To(BeTrue())
+
+			// envtest has no deployment controller, so no Progressing condition exists.
+			converged, err := reconciler.operandsConverged(context.Background(), resources)
+			Expect(err).To(Succeed())
+			Expect(converged).To(BeFalse(), "should not be converged when deployment has no Progressing condition")
+
+			// Patch the deployment status to mark rollout complete.
+			for _, res := range resources {
+				if dep, ok := res.(*appsv1.Deployment); ok {
+					live := &appsv1.Deployment{}
+					Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(dep), live)).To(Succeed())
+					live.Status.ObservedGeneration = live.Generation
+					live.Status.Conditions = []appsv1.DeploymentCondition{
+						{
+							Type:   appsv1.DeploymentProgressing,
+							Status: corev1.ConditionTrue,
+							Reason: "NewReplicaSetAvailable",
+						},
+					}
+					Expect(cl.Status().Update(context.Background(), live)).To(Succeed())
+				}
+			}
+
+			converged, err = reconciler.operandsConverged(context.Background(), resources)
+			Expect(err).To(Succeed())
+			Expect(converged).To(BeTrue(), "should be converged after deployment rollout completes")
+		})
+	})
+
+	It("should set Progressing=True on first sync, remain progressing until rollout completes, then stop", func() {
 		reconciler.ManagedNamespace = DefaultManagedNamespace
 
 		co := &configv1.ClusterOperator{}
 		co.SetName(clusterOperatorName)
-		Expect(cl.Create(context.TODO(), co)).To(Succeed())
+		Expect(cl.Create(context.Background(), co)).To(Succeed())
 
 		operatorConfig := getConfigForPlatform(&configv1.PlatformStatus{Type: configv1.AWSPlatformType})
 		awsResources, err := cloud.GetResources(operatorConfig)
@@ -638,29 +677,45 @@ var _ = Describe("Apply resources should", func() {
 		resources = append(resources, awsResources...)
 
 		// First sync: resources do not yet exist, so applyResources reports updated=true.
-		progressing, err := reconciler.sync(context.TODO(), operatorConfig, nil)
+		progressing, err := reconciler.sync(context.Background(), operatorConfig, nil)
 		Expect(err).To(Succeed())
 		Expect(progressing).To(BeTrue(), "sync should report progressing when resources are newly applied")
 
-		Expect(cl.Get(context.TODO(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		Expect(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
 		progressingCond := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
 		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should exist after first sync")
 		Expect(progressingCond.Status).To(
 			Equal(configv1.ConditionTrue), "Progressing should be True after resources are first applied",
 		)
 
-		// Second sync: resources exist and are unchanged, so applyResources reports updated=false.
-		progressing, err = reconciler.sync(context.TODO(), operatorConfig, nil)
+		// Second sync: resources exist and are unchanged, but deployment rollout is
+		// not complete (envtest has no deployment controller). sync should still
+		// report progressing.
+		progressing, err = reconciler.sync(context.Background(), operatorConfig, nil)
 		Expect(err).To(Succeed())
-		Expect(progressing).To(BeFalse(), "sync should not report progressing when resources are already up to date")
+		Expect(progressing).To(BeTrue(), "sync should report progressing while deployment rollout is incomplete")
 
-		// Progressing remains True because sync() does not clear it; only setStatusAvailable() does.
-		Expect(cl.Get(context.TODO(), client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
-		progressingCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
-		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should still exist after second sync")
-		Expect(progressingCond.Status).To(
-			Equal(configv1.ConditionTrue), "Progressing should remain True until setStatusAvailable is called",
-		)
+		// Patch deployment status to mark rollout complete.
+		for _, res := range resources {
+			if dep, ok := res.(*appsv1.Deployment); ok {
+				live := &appsv1.Deployment{}
+				Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(dep), live)).To(Succeed())
+				live.Status.ObservedGeneration = live.Generation
+				live.Status.Conditions = []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+						Reason: "NewReplicaSetAvailable",
+					},
+				}
+				Expect(cl.Status().Update(context.Background(), live)).To(Succeed())
+			}
+		}
+
+		// Third sync: deployment rollout is complete, sync should report not progressing.
+		progressing, err = reconciler.sync(context.Background(), operatorConfig, nil)
+		Expect(err).To(Succeed())
+		Expect(progressing).To(BeFalse(), "sync should not report progressing once deployment rollout completes")
 	})
 
 	AfterEach(func() {
@@ -1012,7 +1067,7 @@ var _ = Describe("Reconcile progressing flow", func() {
 		}
 	})
 
-	It("sets Progressing=True on first reconcile, then Available on second", func() {
+	It("sets Progressing=True on first reconcile, stays progressing until rollout completes, then Available", func() {
 		// First Reconcile: resources are created, Progressing=True, Available not set.
 		_, err := reconciler.Reconcile(ctx, reconcile.Request{})
 		Expect(err).NotTo(HaveOccurred())
@@ -1042,7 +1097,8 @@ var _ = Describe("Reconcile progressing flow", func() {
 				"Available should not be True while progressing")
 		}
 
-		// Second Reconcile: nothing changed, Progressing=False, Available=True.
+		// Second Reconcile: nothing changed, but deployment rollout is not complete
+		// (envtest has no deployment controller). Progressing should remain True.
 		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -1050,12 +1106,264 @@ var _ = Describe("Reconcile progressing flow", func() {
 		progressingCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
 		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should exist after second reconcile")
 		Expect(progressingCond.Status).To(
-			Equal(configv1.ConditionFalse), "Progressing should be False after second reconcile with no changes",
+			Equal(configv1.ConditionTrue), "Progressing should remain True while deployment rollout is incomplete",
+		)
+
+		// Patch deployment status to mark rollout complete.
+		for _, res := range operandResources {
+			if dep, ok := res.(*appsv1.Deployment); ok {
+				live := &appsv1.Deployment{}
+				Expect(cl.Get(ctx, client.ObjectKeyFromObject(dep), live)).To(Succeed())
+				live.Status.ObservedGeneration = live.Generation
+				live.Status.Conditions = []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+						Reason: "NewReplicaSetAvailable",
+					},
+				}
+				Expect(cl.Status().Update(ctx, live)).To(Succeed())
+			}
+		}
+
+		// Third Reconcile: deployment rollout is complete, Progressing=False, Available=True.
+		_, err = reconciler.Reconcile(ctx, reconcile.Request{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		progressingCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
+		Expect(progressingCond).NotTo(BeNil(), "Progressing condition should exist after third reconcile")
+		Expect(progressingCond.Status).To(
+			Equal(configv1.ConditionFalse), "Progressing should be False after deployment rollout completes",
 		)
 		availCond = v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorAvailable)
-		Expect(availCond).NotTo(BeNil(), "Available condition should exist after second reconcile")
+		Expect(availCond).NotTo(BeNil(), "Available condition should exist after third reconcile")
 		Expect(availCond.Status).To(
-			Equal(configv1.ConditionTrue), "Available should be True after second reconcile",
+			Equal(configv1.ConditionTrue), "Available should be True after deployment rollout completes",
 		)
+	})
+})
+
+var _ = Describe("Rollout completion checks", func() {
+	Context("isDeploymentRolloutComplete", func() {
+		It("is not complete when no conditions exist", func() {
+			deploy := &appsv1.Deployment{}
+			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
+		})
+
+		It("is complete when ObservedGeneration matches and Reason=NewReplicaSetAvailable", func() {
+			deploy := &appsv1.Deployment{}
+			deploy.Generation = 2
+			deploy.Status = appsv1.DeploymentStatus{
+				ObservedGeneration: 2,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+						Reason: "NewReplicaSetAvailable",
+					},
+				},
+			}
+			Expect(isDeploymentRolloutComplete(deploy)).To(BeTrue())
+		})
+
+		It("is not complete when ObservedGeneration lags behind Generation", func() {
+			deploy := &appsv1.Deployment{}
+			deploy.Generation = 3
+			deploy.Status = appsv1.DeploymentStatus{
+				ObservedGeneration: 2,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+						Reason: "NewReplicaSetAvailable",
+					},
+				},
+			}
+			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
+		})
+
+		It("is not complete when Progressing=True with Reason=ReplicaSetUpdated", func() {
+			deploy := &appsv1.Deployment{}
+			deploy.Generation = 1
+			deploy.Status = appsv1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+						Reason: "ReplicaSetUpdated",
+					},
+				},
+			}
+			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
+		})
+
+		It("is not complete when Progressing=False due to deadline exceeded", func() {
+			deploy := &appsv1.Deployment{}
+			deploy.Generation = 1
+			deploy.Status = appsv1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionFalse,
+						Reason: "ProgressDeadlineExceeded",
+					},
+				},
+			}
+			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
+		})
+
+		It("is not complete when Progressing=True with Reason=FoundNewReplicaSet", func() {
+			deploy := &appsv1.Deployment{}
+			deploy.Generation = 1
+			deploy.Status = appsv1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+						Reason: "FoundNewReplicaSet",
+					},
+				},
+			}
+			Expect(isDeploymentRolloutComplete(deploy)).To(BeFalse())
+		})
+
+		It("keys off Progressing condition even when other conditions are present", func() {
+			deploy := &appsv1.Deployment{}
+			deploy.Generation = 1
+			deploy.Status = appsv1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentAvailable,
+						Status: corev1.ConditionTrue,
+						Reason: "MinimumReplicasAvailable",
+					},
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionTrue,
+						Reason: "NewReplicaSetAvailable",
+					},
+				},
+			}
+			Expect(isDeploymentRolloutComplete(deploy)).To(BeTrue())
+		})
+	})
+
+	Context("isDeploymentRolloutStalled", func() {
+		It("is stalled when ProgressDeadlineExceeded", func() {
+			deploy := &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:   appsv1.DeploymentProgressing,
+							Status: corev1.ConditionFalse,
+							Reason: "ProgressDeadlineExceeded",
+						},
+					},
+				},
+			}
+			Expect(isDeploymentRolloutStalled(deploy)).To(BeTrue())
+		})
+
+		It("is not stalled during normal rollout", func() {
+			deploy := &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{
+					Conditions: []appsv1.DeploymentCondition{
+						{
+							Type:   appsv1.DeploymentProgressing,
+							Status: corev1.ConditionTrue,
+							Reason: "ReplicaSetUpdated",
+						},
+					},
+				},
+			}
+			Expect(isDeploymentRolloutStalled(deploy)).To(BeFalse())
+		})
+
+		It("is not stalled when no conditions exist", func() {
+			deploy := &appsv1.Deployment{}
+			Expect(isDeploymentRolloutStalled(deploy)).To(BeFalse())
+		})
+
+		It("ignores stale ProgressDeadlineExceeded from a previous generation", func() {
+			deploy := &appsv1.Deployment{}
+			deploy.Generation = 2
+			deploy.Status = appsv1.DeploymentStatus{
+				ObservedGeneration: 1,
+				Conditions: []appsv1.DeploymentCondition{
+					{
+						Type:   appsv1.DeploymentProgressing,
+						Status: corev1.ConditionFalse,
+						Reason: "ProgressDeadlineExceeded",
+					},
+				},
+			}
+			Expect(isDeploymentRolloutStalled(deploy)).To(BeFalse())
+		})
+	})
+
+	Context("isDaemonSetRolloutComplete", func() {
+		It("is not complete when UpdatedNumberScheduled < DesiredNumberScheduled", func() {
+			ds := &appsv1.DaemonSet{}
+			ds.Generation = 1
+			ds.Status = appsv1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 1,
+			}
+			Expect(isDaemonSetRolloutComplete(ds)).To(BeFalse())
+		})
+
+		It("is not complete when NumberMisscheduled > 0 even if updated count matches", func() {
+			ds := &appsv1.DaemonSet{}
+			ds.Generation = 1
+			ds.Status = appsv1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberMisscheduled:     1,
+			}
+			Expect(isDaemonSetRolloutComplete(ds)).To(BeFalse())
+		})
+
+		It("is not complete when NumberUnavailable > 0 even if scheduled counts match", func() {
+			ds := &appsv1.DaemonSet{}
+			ds.Generation = 1
+			ds.Status = appsv1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberUnavailable:      1,
+			}
+			Expect(isDaemonSetRolloutComplete(ds)).To(BeFalse())
+		})
+
+		It("is not complete when ObservedGeneration lags behind Generation", func() {
+			ds := &appsv1.DaemonSet{}
+			ds.Generation = 2
+			ds.Status = appsv1.DaemonSetStatus{
+				ObservedGeneration:     1,
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+			}
+			Expect(isDaemonSetRolloutComplete(ds)).To(BeFalse())
+		})
+
+		It("is complete when all conditions are met", func() {
+			ds := &appsv1.DaemonSet{}
+			ds.Generation = 2
+			ds.Status = appsv1.DaemonSetStatus{
+				ObservedGeneration:     2,
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberMisscheduled:     0,
+				NumberUnavailable:      0,
+			}
+			Expect(isDaemonSetRolloutComplete(ds)).To(BeTrue())
+		})
 	})
 })

--- a/pkg/controllers/reconcile_dispatch.go
+++ b/pkg/controllers/reconcile_dispatch.go
@@ -1,0 +1,114 @@
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// transientDegradedThreshold is how long transient errors must persist before
+	// the controller sets Degraded=True. This prevents brief
+	// API server blips during upgrades from immediately degrading the operator.
+	transientDegradedThreshold = 2 * time.Minute
+
+	// stalenessWindow is the amount of time a failureWindow can remain "open."
+	// After the stalenessWindow, the failureWindow will be cleared.
+	// Put another way, if the gap since the last observed transient error is greater than
+	// the stalenessWindow, the failure window is reset.
+	// This is used in places where the controller does not automatically re-queue.
+	stalenessWindow = 150 * time.Second
+
+	// noStalenessWindow signals that there is no staleness threshold for this operation
+	noStalenessWindow = 0
+)
+
+// degradedSetter binds ctx to setCondition, returning a no-arg func() error
+// suitable for use as the setDegraded callback in handleTerminal and handleTransient.
+func degradedSetter(ctx context.Context, setCondition func(context.Context) error) func() error {
+	return func() error { return setCondition(ctx) }
+}
+
+// finalizeReconcile is the deferred dispatcher shared by CloudConfigReconciler and
+// TrustedCABundleReconciler. Terminal errors degrade immediately; transient errors
+// degrade only after threshold; nil errors invoke clearFn.
+func finalizeReconcile(
+	fw *failureWindow,
+	clk clock.PassiveClock,
+	staleAfter, threshold time.Duration,
+	name string,
+	clearFn func(),
+	setDegraded func() error,
+	result *ctrl.Result,
+	retErr *error,
+) {
+	if *retErr == nil {
+		clearFn()
+		return
+	}
+	if errors.Is(*retErr, reconcile.TerminalError(nil)) {
+		*result, *retErr = fw.handleTerminal(name, *retErr, setDegraded)
+	} else {
+		*result, *retErr = fw.handleTransient(clk.Now(), staleAfter, threshold, name, *retErr, setDegraded)
+	}
+}
+
+// failureWindow tracks consecutive transient failures. All methods are safe for concurrent use.
+type failureWindow struct {
+	mu                      sync.Mutex
+	consecutiveFailureSince *time.Time
+	lastTransientFailureAt  *time.Time
+}
+
+// clear resets the failure window. Call this on every successful reconcile.
+func (fw *failureWindow) clear() {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	fw.consecutiveFailureSince = nil
+	fw.lastTransientFailureAt = nil
+}
+
+// observe records a transient failure at now and returns the elapsed time since
+// the window started plus a boolean indicating whether the window was just opened
+// or restarted. staleAfter controls stale-window detection: if the gap since the
+// last observed failure exceeds staleAfter, the window restarts. Pass 0 to disable.
+func (fw *failureWindow) observe(now time.Time, staleAfter time.Duration) (elapsed time.Duration, started bool) {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+	stale := staleAfter > 0 && fw.lastTransientFailureAt != nil && now.Sub(*fw.lastTransientFailureAt) > staleAfter
+	if fw.consecutiveFailureSince == nil || stale {
+		fw.consecutiveFailureSince = &now
+		fw.lastTransientFailureAt = &now
+		return 0, true
+	}
+	fw.lastTransientFailureAt = &now
+	return now.Sub(*fw.consecutiveFailureSince), false
+}
+
+// handleTransient records a transient failure and degrades only after threshold has elapsed.
+// name labels log messages. staleAfter controls stale-window restart (pass 0 to disable).
+// setDegraded is invoked only when the threshold is exceeded.
+// Always returns a non-nil error so controller-runtime requeues with exponential backoff.
+func (fw *failureWindow) handleTransient(now time.Time, staleAfter, threshold time.Duration, name string, err error, setDegraded func() error) (ctrl.Result, error) {
+	elapsed, started := fw.observe(now, staleAfter)
+	if started {
+		klog.V(4).Infof("%s: transient failure started (%v), will degrade after %s", name, err, threshold)
+		return ctrl.Result{}, err
+	}
+	if elapsed < threshold {
+		klog.V(4).Infof("%s: transient failure ongoing for %s (threshold %s): %v", name, elapsed, threshold, err)
+		return ctrl.Result{}, err
+	}
+	klog.Warningf("%s: transient failure exceeded threshold (%s), setting degraded condition for controller: %v", name, elapsed, err)
+	if setErr := setDegraded(); setErr != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to set degraded condition: %w", setErr)
+	}
+	return ctrl.Result{}, err
+}

--- a/pkg/controllers/reconcile_dispatch_test.go
+++ b/pkg/controllers/reconcile_dispatch_test.go
@@ -1,0 +1,44 @@
+package controllers
+
+import (
+	"context"
+	"reflect"
+
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// errorInjectingClient wraps a real client and injects errors on Get calls
+// for a specific object type. This simulates transient API server failures
+// (e.g. network blips) without depending on any internal controller code path.
+// The getErr pointer allows tests to toggle faults between reconcile calls.
+type errorInjectingClient struct {
+	client.Client
+	getErr   *error
+	failType client.Object
+}
+
+func (c *errorInjectingClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.getErr != nil && *c.getErr != nil && reflect.TypeOf(obj) == reflect.TypeOf(c.failType) {
+		return *c.getErr
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}
+
+func deleteClusterOperator(ctx context.Context, cl client.Client) {
+	co := &configv1.ClusterOperator{}
+	if err := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); err == nil {
+		Eventually(func() error {
+			err := cl.Delete(ctx, co)
+			if err == nil || apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}).Should(Succeed())
+	}
+	Eventually(func() error {
+		return cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)
+	}).Should(MatchError(apierrors.IsNotFound, "IsNotFound"))
+}

--- a/pkg/controllers/status.go
+++ b/pkg/controllers/status.go
@@ -110,6 +110,20 @@ func (r *ClusterOperatorStatusClient) setStatusProgressing(ctx context.Context, 
 	return r.syncStatus(ctx, co, conds, overrides)
 }
 
+func (r *ClusterOperatorStatusClient) ensureStatusProgressing(ctx context.Context, overrides []configv1.ClusterOperatorStatusCondition) error {
+	co, err := r.getOrCreateClusterOperator(ctx)
+	if err != nil {
+		return err
+	}
+	progressing := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorProgressing)
+	upgradeable := v1helpers.FindStatusCondition(co.Status.Conditions, configv1.OperatorUpgradeable)
+	if progressing != nil && progressing.Status == configv1.ConditionTrue &&
+		upgradeable != nil && upgradeable.Status == configv1.ConditionTrue {
+		return nil
+	}
+	return r.setStatusProgressing(ctx, overrides)
+}
+
 // setStatusAvailable sets the Available condition to True, with the given reason
 // and message, and sets both the Progressing and Degraded conditions to False.
 func (r *ClusterOperatorStatusClient) setStatusAvailable(ctx context.Context, overrides []configv1.ClusterOperatorStatusCondition) error {

--- a/pkg/controllers/trusted_ca_bundle_controller.go
+++ b/pkg/controllers/trusted_ca_bundle_controller.go
@@ -43,6 +43,7 @@ type TrustedCABundleReconciler struct {
 	ClusterOperatorStatusClient
 	Scheme          *runtime.Scheme
 	trustBundlePath string
+	failures        failureWindow
 }
 
 // isSpecTrustedCASet returns true if spec.trustedCA of proxyConfig is set.
@@ -50,8 +51,20 @@ func isSpecTrustedCASet(proxyConfig *configv1.ProxySpec) bool {
 	return len(proxyConfig.TrustedCA.Name) > 0
 }
 
-func (r *TrustedCABundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *TrustedCABundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (result ctrl.Result, retErr error) {
 	klog.V(1).Infof("%s emitted event, syncing %s ConfigMap", req, trustedCAConfigMapName)
+
+	// partialRun is set to true on the early-exit path where the event is for
+	// an unrelated ConfigMap. That path returns available=true but should NOT
+	// reset an ongoing transient failure window from a previous full reconcile.
+	partialRun := false
+
+	// transientDegradedThreshold is used as both the degraded threshold and staleness value.
+	defer finalizeReconcile(&r.failures, r.Clock, stalenessWindow, transientDegradedThreshold, "TrustedCABundleReconciler", func() {
+		if !partialRun {
+			r.failures.clear()
+		}
+	}, degradedSetter(ctx, r.setDegradedCondition), &result, &retErr)
 
 	proxyConfig := &configv1.Proxy{}
 	if err := r.Get(ctx, types.NamespacedName{Name: proxyResourceName}, proxyConfig); err != nil {
@@ -62,63 +75,51 @@ func (r *TrustedCABundleReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			if err := r.setAvailableCondition(ctx); err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to set conditions for trusted CA bundle controller: %v", err)
 			}
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, nil // defer clears failure window
 		}
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for trusted CA bundle controller: %v", err)
-		}
-		// Error reading the object - requeue the request.
-		return reconcile.Result{}, fmt.Errorf("failed to get proxy '%s': %v", req.Name, err)
+		// Non-NotFound: transient API error.
+		return ctrl.Result{}, fmt.Errorf("failed to get proxy '%s': %w", req.Name, err) // transient
 	}
 
 	// Check if changed config map in 'openshift-config' namespace is proxy trusted ca.
-	// If not, return early
+	// If not, return early without resetting the failure window (partialRun=true).
 	if req.Namespace == OpenshiftConfigNamespace && proxyConfig.Spec.TrustedCA.Name != req.Name {
+		partialRun = true
+		klog.V(1).Infof("changed config map %s is not a proxy trusted ca, skipping", req)
 		if err := r.setAvailableCondition(ctx); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to set conditions for trusted CA bundle controller: %v", err)
 		}
-
-		klog.V(1).Infof("changed config map %s is not a proxy trusted ca, skipping", req)
 		return reconcile.Result{}, nil
 	}
 
 	systemTrustBundle, err := r.getSystemTrustBundle()
 	if err != nil {
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for trusted CA bundle controller: %v", err)
-		}
-		return reconcile.Result{}, fmt.Errorf("failed to get system trust bundle: %v", err)
+		// Node cert store may be updating during upgrade: transient.
+		return ctrl.Result{}, fmt.Errorf("failed to get system trust bundle: %w", err) // transient
 	}
 
 	proxyCABundle, mergedTrustBundle, err := r.addProxyCABundle(ctx, proxyConfig, systemTrustBundle)
 	if err != nil {
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for trusted CA bundle controller: %v", err)
-		}
-		return reconcile.Result{}, fmt.Errorf("can not check and add proxy CA to merged bundle: %v", err)
+		// Combined cert bundle is corrupt: terminal.
+		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("can not check and add proxy CA to merged bundle: %w", err))
 	}
 
 	_, mergedTrustBundle, err = r.addCloudConfigCABundle(ctx, proxyCABundle, mergedTrustBundle)
 	if err != nil {
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for trusted CA bundle controller: %v", err)
-		}
-		return reconcile.Result{}, fmt.Errorf("can not check and add cloud-config CA to merged bundle: %v", err)
+		// Combined cert bundle is corrupt: terminal.
+		return ctrl.Result{}, reconcile.TerminalError(fmt.Errorf("can not check and add cloud-config CA to merged bundle: %w", err))
 	}
 
 	ccmTrustedConfigMap := r.makeCABundleConfigMap(mergedTrustBundle)
 	if err := r.createOrUpdateConfigMap(ctx, ccmTrustedConfigMap); err != nil {
-		if err := r.setDegradedCondition(ctx); err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to set conditions for trusted CA bundle controller: %v", err)
-		}
-		return reconcile.Result{}, fmt.Errorf("can not update target trust bundle configmap: %v", err)
+		return ctrl.Result{}, fmt.Errorf("can not update target trust bundle configmap: %w", err) // transient
 	}
 
 	if err := r.setAvailableCondition(ctx); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set conditions for trusted CA bundle controller: %v", err)
 	}
 
-	return ctrl.Result{}, nil
+	return ctrl.Result{}, nil // defer clears failure window
 }
 
 // addProxyCABundle checks ca bundle referred by Proxy resource and adds it to passed bundle

--- a/pkg/controllers/trusted_ca_bundle_controller_test.go
+++ b/pkg/controllers/trusted_ca_bundle_controller_test.go
@@ -162,18 +162,7 @@ var _ = Describe("Trusted CA bundle sync controller", func() {
 			GracePeriodSeconds: ptr.To[int64](0),
 		}
 
-		co := &v1.ClusterOperator{}
-		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
-		if err == nil || !apierrors.IsNotFound(err) {
-			Eventually(func() error {
-				err := cl.Delete(context.Background(), co)
-				if err == nil || apierrors.IsNotFound(err) {
-					return nil
-				}
-				return err
-			}).Should(Succeed())
-		}
-		Eventually(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co))).Should(BeTrue())
+		deleteClusterOperator(context.Background(), cl)
 
 		if proxyResource != nil {
 			Expect(cl.Delete(ctx, proxyResource, deleteOptions)).To(Succeed())
@@ -324,20 +313,7 @@ var _ = Describe("Trusted CA bundle reconciler unit tests", func() {
 	ctx := context.Background()
 
 	AfterEach(func() {
-		co := &v1.ClusterOperator{}
-		if err := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); err == nil {
-			Expect(cl.Delete(ctx, co)).To(Succeed())
-			Eventually(func() error {
-				err := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)
-				if apierrors.IsNotFound(err) {
-					return nil
-				}
-				if err != nil {
-					return err
-				}
-				return fmt.Errorf("expected ClusterOperator to be deleted")
-			}).Should(Succeed())
-		}
+		deleteClusterOperator(ctx, cl)
 	})
 
 	It("reconcile should succeed and be available if no proxy resource found", func() {

--- a/pkg/controllers/trusted_ca_bundle_controller_test.go
+++ b/pkg/controllers/trusted_ca_bundle_controller_test.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	clocktesting "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -164,10 +165,13 @@ var _ = Describe("Trusted CA bundle sync controller", func() {
 		co := &v1.ClusterOperator{}
 		err := cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co)
 		if err == nil || !apierrors.IsNotFound(err) {
-			Eventually(func() bool {
+			Eventually(func() error {
 				err := cl.Delete(context.Background(), co)
-				return err == nil || apierrors.IsNotFound(err)
-			}).Should(BeTrue())
+				if err == nil || apierrors.IsNotFound(err) {
+					return nil
+				}
+				return err
+			}).Should(Succeed())
 		}
 		Eventually(apierrors.IsNotFound(cl.Get(context.Background(), client.ObjectKey{Name: clusterOperatorName}, co))).Should(BeTrue())
 
@@ -294,9 +298,16 @@ var _ = Describe("Trusted CA bundle sync controller", func() {
 
 	It("merged bundle should be generated without cloud-config at all", func() {
 		Expect(cl.Delete(ctx, syncedCloudConfigConfigMap)).To(Succeed())
-		Eventually(func() bool {
-			return apierrors.IsNotFound(cl.Get(ctx, client.ObjectKeyFromObject(syncedCloudConfigConfigMap), &corev1.ConfigMap{}))
-		}).Should(BeTrue())
+		Eventually(func() error {
+			err := cl.Get(ctx, client.ObjectKeyFromObject(syncedCloudConfigConfigMap), &corev1.ConfigMap{})
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+			return fmt.Errorf("expected synced cloud config ConfigMap to be deleted")
+		}).Should(Succeed())
 		syncedCloudConfigConfigMap = nil
 
 		mergedTrustedCA := &corev1.ConfigMap{}
@@ -306,6 +317,312 @@ var _ = Describe("Trusted CA bundle sync controller", func() {
 		Expect(cl.Delete(ctx, mergedTrustedCA)).To(Succeed())
 
 		Eventually(checkMergedTrustedCAConfig(3, "Amazon")).Should(Succeed())
+	})
+})
+
+var _ = Describe("Trusted CA bundle reconciler unit tests", func() {
+	ctx := context.Background()
+
+	AfterEach(func() {
+		co := &v1.ClusterOperator{}
+		if err := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); err == nil {
+			Expect(cl.Delete(ctx, co)).To(Succeed())
+			Eventually(func() error {
+				err := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf("expected ClusterOperator to be deleted")
+			}).Should(Succeed())
+		}
+	})
+
+	It("reconcile should succeed and be available if no proxy resource found", func() {
+		reconciler := &TrustedCABundleReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            clocktesting.NewFakePassiveClock(time.Now()),
+				ManagedNamespace: testManagedNamespace,
+			},
+			trustBundlePath: systemCAValid,
+		}
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(Succeed())
+
+		co := &v1.ClusterOperator{}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		var availCond *v1.ClusterOperatorStatusCondition
+		for i := range co.Status.Conditions {
+			if co.Status.Conditions[i].Type == trustedCABundleControllerAvailableCondition {
+				availCond = &co.Status.Conditions[i]
+				break
+			}
+		}
+		Expect(availCond).NotTo(BeNil())
+		Expect(availCond.Status).To(Equal(v1.ConditionTrue))
+	})
+
+	It("stale failure window should be restarted when gap since last error exceeds threshold", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		reconciler := &TrustedCABundleReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            fakeClock,
+				ManagedNamespace: testManagedNamespace,
+			},
+			trustBundlePath: "/broken/ca/path.pem", // unreadable → transient error
+		}
+
+		// Create a Proxy so the reconcile progresses to getSystemTrustBundle.
+		proxy := &v1.Proxy{ObjectMeta: metav1.ObjectMeta{Name: proxyResourceName}}
+		Expect(cl.Create(ctx, proxy)).To(Succeed())
+		DeferCleanup(func() { _ = cl.Delete(ctx, proxy) })
+
+		// Step 1: First transient error; failure window opens at T0.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(HaveOccurred())
+		Expect(reconciler.failures.consecutiveFailureSince).NotTo(BeNil())
+
+		// Step 2: Advance clock past the staleness threshold — simulates a gap with no reconciles
+		// (e.g., system recovered, no events fired for a long time).
+		fakeClock.Step(stalenessWindow + time.Second)
+
+		// Step 3: New transient error arrives. The stale-window logic should detect that
+		// lastTransientFailureAt is more than the threshold ago and restart the window
+		// from 'now', NOT degrade immediately.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(HaveOccurred())
+
+		co := &v1.ClusterOperator{}
+		if getErr := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); getErr == nil {
+			for _, cond := range co.Status.Conditions {
+				if cond.Type == trustedCABundleControllerDegradedCondition {
+					Expect(cond.Status).NotTo(Equal(v1.ConditionTrue),
+						"should not degrade immediately after a gap — window should restart")
+				}
+			}
+		}
+		// consecutiveFailureSince should now be 'now', not the original T0.
+		Expect(reconciler.failures.consecutiveFailureSince).NotTo(BeNil())
+		Expect(fakeClock.Now().Sub(*reconciler.failures.consecutiveFailureSince)).To(BeNumerically("<", time.Second),
+			"window should have been restarted to ~now, not retained from original T0")
+	})
+
+	It("partialRun should not clear failure window from a previous transient error", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		reconciler := &TrustedCABundleReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            fakeClock,
+				ManagedNamespace: testManagedNamespace,
+			},
+			trustBundlePath: "/broken/ca/path.pem", // unreadable → transient error
+		}
+
+		// Create a Proxy whose TrustedCA points to "user-ca-bundle".
+		proxy := &v1.Proxy{
+			ObjectMeta: metav1.ObjectMeta{Name: proxyResourceName},
+			Spec: v1.ProxySpec{
+				TrustedCA: v1.ConfigMapNameReference{Name: additionalCAConfigMapName},
+			},
+		}
+		Expect(cl.Create(ctx, proxy)).To(Succeed())
+		DeferCleanup(func() { _ = cl.Delete(ctx, proxy) })
+
+		// Step 1: Transient error opens the failure window at T0.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(HaveOccurred())
+		Expect(reconciler.failures.consecutiveFailureSince).NotTo(BeNil(),
+			"failure window should be open after transient error")
+
+		windowStart := *reconciler.failures.consecutiveFailureSince
+
+		// Step 2: Advance clock partway through the threshold, then send an event
+		// for an unrelated ConfigMap in the openshift-config namespace.
+		// This triggers the partialRun path (req.Namespace == OpenshiftConfigNamespace
+		// && req.Name != proxy.Spec.TrustedCA.Name). The reconcile returns nil,
+		// but the failure window should NOT be cleared.
+		fakeClock.Step(transientDegradedThreshold / 2)
+
+		// Fix the trust bundle path so the full reconcile path would succeed,
+		// proving that the partial-run path is what preserves the window.
+		reconciler.trustBundlePath = systemCAValid
+
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Namespace: OpenshiftConfigNamespace,
+				Name:      "some-unrelated-configmap",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred(), "partial run should succeed")
+		Expect(reconciler.failures.consecutiveFailureSince).NotTo(BeNil(),
+			"failure window should still be open after partial run")
+		Expect(*reconciler.failures.consecutiveFailureSince).To(Equal(windowStart),
+			"failure window start should be unchanged by partial run")
+	})
+
+	It("full successful reconcile should clear failure window unlike partialRun", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		reconciler := &TrustedCABundleReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            fakeClock,
+				ManagedNamespace: testManagedNamespace,
+			},
+			trustBundlePath: "/broken/ca/path.pem",
+		}
+
+		// Create a Proxy whose TrustedCA points to "user-ca-bundle".
+		proxy := &v1.Proxy{
+			ObjectMeta: metav1.ObjectMeta{Name: proxyResourceName},
+			Spec: v1.ProxySpec{
+				TrustedCA: v1.ConfigMapNameReference{Name: additionalCAConfigMapName},
+			},
+		}
+		Expect(cl.Create(ctx, proxy)).To(Succeed())
+		DeferCleanup(func() { _ = cl.Delete(ctx, proxy) })
+
+		// Create the user CA bundle ConfigMap so the full path can succeed.
+		userCA, err := makeValidUserCAConfigMap(additionalAmazonCAPemPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cl.Create(ctx, userCA)).To(Succeed())
+		DeferCleanup(func() { _ = cl.Delete(ctx, userCA) })
+
+		// Step 1: Transient error opens the failure window.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(HaveOccurred())
+		Expect(reconciler.failures.consecutiveFailureSince).NotTo(BeNil())
+
+		// Step 2: Fix the trust bundle path and trigger a full reconcile
+		// (request is NOT for an unrelated ConfigMap in openshift-config).
+		reconciler.trustBundlePath = systemCAValid
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).NotTo(HaveOccurred(), "full successful reconcile should not error")
+		Expect(reconciler.failures.consecutiveFailureSince).To(BeNil(),
+			"full successful reconcile should clear the failure window")
+	})
+
+	It("partialRun preserves failure window so degradation fires after threshold", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		reconciler := &TrustedCABundleReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            fakeClock,
+				ManagedNamespace: testManagedNamespace,
+			},
+			trustBundlePath: "/broken/ca/path.pem",
+		}
+
+		proxy := &v1.Proxy{
+			ObjectMeta: metav1.ObjectMeta{Name: proxyResourceName},
+			Spec: v1.ProxySpec{
+				TrustedCA: v1.ConfigMapNameReference{Name: additionalCAConfigMapName},
+			},
+		}
+		Expect(cl.Create(ctx, proxy)).To(Succeed())
+		DeferCleanup(func() { _ = cl.Delete(ctx, proxy) })
+
+		// Step 1: Transient error opens the failure window at T0.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(HaveOccurred())
+
+		// Step 2: Advance partway and send an unrelated ConfigMap event (partialRun).
+		// Window stays open.
+		fakeClock.Step(transientDegradedThreshold / 2)
+		reconciler.trustBundlePath = systemCAValid
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: client.ObjectKey{
+				Namespace: OpenshiftConfigNamespace,
+				Name:      "some-unrelated-configmap",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Step 3: Advance past the threshold and trigger another transient error.
+		// Because partialRun preserved the window, the total elapsed time from
+		// the original failure exceeds the threshold → degraded should be set.
+		fakeClock.Step(transientDegradedThreshold/2 + time.Second)
+		reconciler.trustBundlePath = "/broken/ca/path.pem"
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(HaveOccurred())
+
+		co := &v1.ClusterOperator{}
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		var degradedCond *v1.ClusterOperatorStatusCondition
+		for i := range co.Status.Conditions {
+			if co.Status.Conditions[i].Type == trustedCABundleControllerDegradedCondition {
+				degradedCond = &co.Status.Conditions[i]
+				break
+			}
+		}
+		Expect(degradedCond).NotTo(BeNil())
+		Expect(degradedCond.Status).To(Equal(v1.ConditionTrue),
+			"should degrade because partialRun preserved the failure window past the threshold")
+	})
+
+	It("should not degrade on transient error before threshold, but degrade after threshold", func() {
+		fakeClock := clocktesting.NewFakeClock(time.Now())
+		reconciler := &TrustedCABundleReconciler{
+			ClusterOperatorStatusClient: ClusterOperatorStatusClient{
+				Client:           cl,
+				Clock:            fakeClock,
+				ManagedNamespace: testManagedNamespace,
+			},
+			trustBundlePath: "/broken/ca/path.pem", // unreadable → transient error
+		}
+
+		// Create a Proxy so the Proxy get succeeds and we reach the system trust bundle read.
+		proxy := &v1.Proxy{ObjectMeta: metav1.ObjectMeta{Name: proxyResourceName}}
+		Expect(cl.Create(ctx, proxy)).To(Succeed())
+		DeferCleanup(func() { _ = cl.Delete(ctx, proxy) })
+
+		// First reconcile at T0: transient failure starts; error is returned but no degraded condition set.
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(HaveOccurred())
+		co := &v1.ClusterOperator{}
+		if getErr := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); getErr == nil {
+			for _, cond := range co.Status.Conditions {
+				if cond.Type == trustedCABundleControllerDegradedCondition {
+					Expect(cond.Status).NotTo(Equal(v1.ConditionTrue), "should not be degraded before threshold")
+				}
+			}
+		}
+
+		// Advance clock to mid-window (half the threshold) and reconcile again to simulate
+		// continuous failures. This updates lastTransientFailureAt, keeping it fresh.
+		fakeClock.Step(transientDegradedThreshold / 2)
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(HaveOccurred())
+		if getErr := cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co); getErr == nil {
+			for _, cond := range co.Status.Conditions {
+				if cond.Type == trustedCABundleControllerDegradedCondition {
+					Expect(cond.Status).NotTo(Equal(v1.ConditionTrue), "should not be degraded before threshold")
+				}
+			}
+		}
+
+		// Advance clock so total elapsed from T0 exceeds the threshold, but the gap since the
+		// most recent failure (lastTransientFailureAt) is less than the threshold. This ensures
+		// the degradation path is taken rather than the stale-window restart path.
+		fakeClock.Step(transientDegradedThreshold/2 + time.Second)
+
+		// Final reconcile: threshold exceeded, controller sets degraded.
+		_, err = reconciler.Reconcile(ctx, ctrl.Request{})
+		Expect(err).To(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKey{Name: clusterOperatorName}, co)).To(Succeed())
+		var degradedCond *v1.ClusterOperatorStatusCondition
+		for i := range co.Status.Conditions {
+			if co.Status.Conditions[i].Type == trustedCABundleControllerDegradedCondition {
+				degradedCond = &co.Status.Conditions[i]
+				break
+			}
+		}
+		Expect(degradedCond).NotTo(BeNil())
+		Expect(degradedCond.Status).To(Equal(v1.ConditionTrue))
 	})
 })
 


### PR DESCRIPTION
 Summary

- All three reconcilers (CloudConfigReconciler, TrustedCABundleReconciler, CloudOperatorReconciler) now distinguish transient errors (API blips) from permanent errors (corrupt config, unsupported platform). Transient errors are silently requeued and only set Degraded=True after a threshold (2m for sub-controllers, 2m30s for the main controller). Permanent errors degrade immediately without requeue.
- Failure handling is consolidated into a shared finalizeReconcile() deferred function in reconcile_dispatch.go, using controller-runtime's TerminalError to classify errors.
- Fix Progressing=True being immediately overwritten by Available — sync() now returns (bool, error) so Reconcile skips setStatusAvailable when resources were just updated.


This depends on https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/484 to avoid the race that required the revert previously. 
