### PR TITLE
OCPBUGS-99755: OTE: fix AWS endpoint resolution for non-standard partitions

### DIFF
--- a/openshift-tests/ccm-aws-tests/e2e/aws/helper.go
+++ b/openshift-tests/ccm-aws-tests/e2e/aws/helper.go
@@ -59,9 +59,6 @@ func createAWSClientLoadBalancer(ctx context.Context) (*elbv2.Client, error) {
 
 	return elbv2.NewFromConfig(cfg, func(o *elbv2.Options) {
 		o.Retryer = customRetryer
-		// Use regional public endpoints to prevent malformed or unreachable
-		// (from test binary, which usually runs outside cluster's VPC) endpoints.
-		o.BaseEndpoint = aws.String(fmt.Sprintf("https://elasticloadbalancing.%s.amazonaws.com", cfg.Region))
 	}), nil
 }
 
@@ -136,11 +133,7 @@ func createAWSClientEC2(ctx context.Context) (*ec2.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ec2.NewFromConfig(cfg, func(o *ec2.Options) {
-		// Use regional public endpoints to prevent malformed or unreachable
-		// (from test binary, which usually runs outside cluster's VPC) endpoints.
-		o.BaseEndpoint = aws.String(fmt.Sprintf("https://ec2.%s.amazonaws.com", cfg.Region))
-	}), nil
+	return ec2.NewFromConfig(cfg), nil
 }
 
 // getAWSSecurityGroup retrieves a security group by ID using the AWS EC2 client.


### PR DESCRIPTION
## Description

The `BaseEndpoint` for ELBv2 and EC2 clients was hardcoded to `.amazonaws.com`, which is incorrect for non-standard AWS partitions like EUSC (`.amazonaws.eu`). This caused API calls to fail on EUSC clusters because the requests were sent to the wrong domain.
    
This PR removes the `BaseEndpoint` override to let the AWS SDK automatically resolve to an partition-aware endpoint.

See also https://github.com/openshift/cluster-cloud-controller-manager-operator/pull/464.

**Note**: Originally, I thought it was due to an outdated AWS SDK deps, but the endpoint resolution is fine (without base endpoint override) thanks to the compatible core config module. Thus, there is no longer any need to upgrade go deps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS load balancer and EC2 connectivity by stopping the use of hardcoded public regional endpoints, allowing the SDK to resolve the correct endpoints automatically.
  * Enhanced compatibility with varied AWS environments and endpoint configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->