### PR TITLE
CORS-4551: GCP: mount bound sa token volume

### DIFF
--- a/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
+++ b/pkg/cloud/gcp/assets/cloud-controller-manager.yaml
@@ -117,6 +117,9 @@ spec:
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
               readOnly: true
+            - name: bound-sa-token
+              mountPath: /var/run/secrets/openshift/serviceaccount
+              readOnly: true
       volumes:
         - name: config-gccm
           configMap:
@@ -137,3 +140,9 @@ spec:
             items:
               - key: ca-bundle.crt
                 path: tls-ca-bundle.pem
+        - name: bound-sa-token
+          projected:
+            sources:
+            - serviceAccountToken:
+                path: token
+                audience: openshift


### PR DESCRIPTION
On GCP, we should mount the bound sa token volume, similarly to how it is done on Azure. Typically the volume is mounted by the CCO webhook, but that pattern is problematic if the CCM needs the projected credentials to schedule the CCO to run it's webhook, in which case we hit a deadlock. We can avoid this entirely by simply always mounting.

This doesn't occur in most installs because the CCM is authenticated by a VM attached to the service account, but GCD uses a projected credential and we want to move that direction for all installs because you can dynamically upgrade permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an OpenShift-audience service-account token to the cloud controller manager deployment.
  * The token is securely mounted for use at `/var/run/secrets/openshift/serviceaccount`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->